### PR TITLE
Add opportunity close tracking data across backend and frontend

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -90,7 +90,7 @@ func SeedData(db *gorm.DB) error {
 			Notes:      fmt.Sprintf("Employee %d", i+1),
 		}
 	}
-	
+
 	// Add Lonny Lohnsteich as employee #21
 	lonnyHireDate := time.Date(2024, time.October, 1, 0, 0, 0, 0, time.UTC)
 	employees[20] = models.Employee{
@@ -216,6 +216,20 @@ func SeedData(db *gorm.DB) error {
 		models.OpportunityStageClosedLost,
 	}
 
+	closeWonReasons := []string{
+		"Signed multi-year agreement",
+		"Expanded footprint after pilot",
+		"Customer upgraded to enterprise tier",
+		"Bundled services sealed the deal",
+	}
+
+	closeLostReasons := []string{
+		"Chose incumbent vendor",
+		"Budget was reallocated",
+		"Scope delayed until next fiscal year",
+		"Lost to lower-cost competitor",
+	}
+
 	opportunities := make([]models.Opportunity, len(opportunityNames))
 	for i := range opportunityNames {
 		account := accounts[i%len(accounts)]
@@ -243,7 +257,7 @@ func SeedData(db *gorm.DB) error {
 
 		description := fmt.Sprintf("%s opportunity for %s with focus on solution alignment and value realization.", opportunityNames[i], account.Name)
 
-		opportunities[i] = models.Opportunity{
+		opportunity := models.Opportunity{
 			Name:              fmt.Sprintf("%s - %s", account.Name, opportunityNames[i]),
 			AccountID:         account.ID,
 			ContactID:         contactID,
@@ -254,6 +268,20 @@ func SeedData(db *gorm.DB) error {
 			Stage:             stage,
 			Description:       description,
 		}
+
+		if stage == models.OpportunityStageClosedWon || stage == models.OpportunityStageClosedLost {
+			closedAt := expectedClose.AddDate(0, 0, -2+(i%5))
+			opportunity.ClosedAt = &closedAt
+			opportunity.ClosedByEmployeeID = &owner.ID
+
+			if stage == models.OpportunityStageClosedWon {
+				opportunity.CloseReason = closeWonReasons[i%len(closeWonReasons)]
+			} else {
+				opportunity.CloseReason = closeLostReasons[i%len(closeLostReasons)]
+			}
+		}
+
+		opportunities[i] = opportunity
 	}
 
 	for i := range opportunities {

--- a/backend/models/opportunity.go
+++ b/backend/models/opportunity.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -45,23 +47,27 @@ func (s OpportunityStage) String() string {
 
 // Opportunity represents a sales opportunity tied to an account/contact
 type Opportunity struct {
-	ID                uint             `json:"ID" gorm:"primaryKey" odata:"key"`
-	AccountID         uint             `json:"AccountID" gorm:"not null;index" odata:"required"`
-	ContactID         *uint            `json:"ContactID" gorm:"index"`
-	OwnerEmployeeID   *uint            `json:"OwnerEmployeeID" gorm:"index"`
-	Name              string           `json:"Name" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
-	Amount            float64          `json:"Amount" gorm:"not null;type:numeric(12,2)" odata:"required"`
-	Probability       int              `json:"Probability" gorm:"not null;type:integer;default:50" odata:"required"`
-	ExpectedCloseDate *time.Time       `json:"ExpectedCloseDate"`
-	Stage             OpportunityStage `json:"Stage" gorm:"not null;type:integer;default:1" odata:"required,enum=OpportunityStage"`
-	Description       string           `json:"Description" gorm:"type:text"`
-	CreatedAt         time.Time        `json:"CreatedAt" gorm:"autoCreateTime"`
-	UpdatedAt         time.Time        `json:"UpdatedAt" gorm:"autoUpdateTime"`
+	ID                 uint             `json:"ID" gorm:"primaryKey" odata:"key"`
+	AccountID          uint             `json:"AccountID" gorm:"not null;index" odata:"required"`
+	ContactID          *uint            `json:"ContactID" gorm:"index"`
+	OwnerEmployeeID    *uint            `json:"OwnerEmployeeID" gorm:"index"`
+	Name               string           `json:"Name" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
+	Amount             float64          `json:"Amount" gorm:"not null;type:numeric(12,2)" odata:"required"`
+	Probability        int              `json:"Probability" gorm:"not null;type:integer;default:50" odata:"required"`
+	ExpectedCloseDate  *time.Time       `json:"ExpectedCloseDate"`
+	Stage              OpportunityStage `json:"Stage" gorm:"not null;type:integer;default:1" odata:"required,enum=OpportunityStage"`
+	Description        string           `json:"Description" gorm:"type:text"`
+	ClosedAt           *time.Time       `json:"ClosedAt"`
+	CloseReason        string           `json:"CloseReason" gorm:"type:text"`
+	ClosedByEmployeeID *uint            `json:"ClosedByEmployeeID" gorm:"index"`
+	CreatedAt          time.Time        `json:"CreatedAt" gorm:"autoCreateTime"`
+	UpdatedAt          time.Time        `json:"UpdatedAt" gorm:"autoUpdateTime"`
 
 	// Navigation properties
-	Account *Account  `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
-	Contact *Contact  `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
-	Owner   *Employee `json:"Owner" gorm:"foreignKey:OwnerEmployeeID" odata:"navigation"`
+	Account  *Account  `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
+	Contact  *Contact  `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
+	Owner    *Employee `json:"Owner" gorm:"foreignKey:OwnerEmployeeID" odata:"navigation"`
+	ClosedBy *Employee `json:"ClosedBy" gorm:"foreignKey:ClosedByEmployeeID" odata:"navigation"`
 }
 
 // TableName specifies the table name for GORM
@@ -71,17 +77,56 @@ func (Opportunity) TableName() string {
 
 // BeforeSave validates relationships before persisting changes
 func (opportunity *Opportunity) BeforeSave(tx *gorm.DB) error {
-	if opportunity.ContactID == nil {
-		return nil
+	if opportunity.ContactID != nil {
+		var contact Contact
+		if err := tx.Select("account_id").First(&contact, *opportunity.ContactID).Error; err != nil {
+			return err
+		}
+
+		if contact.AccountID != opportunity.AccountID {
+			return fmt.Errorf("contact %d does not belong to account %d", *opportunity.ContactID, opportunity.AccountID)
+		}
 	}
 
-	var contact Contact
-	if err := tx.Select("account_id").First(&contact, *opportunity.ContactID).Error; err != nil {
-		return err
+	previousWasClosed := false
+
+	if opportunity.ID != 0 {
+		var existing Opportunity
+		if err := tx.Select("stage").First(&existing, opportunity.ID).Error; err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+		} else {
+			previousWasClosed = existing.Stage == OpportunityStageClosedWon || existing.Stage == OpportunityStageClosedLost
+		}
 	}
 
-	if contact.AccountID != opportunity.AccountID {
-		return fmt.Errorf("contact %d does not belong to account %d", *opportunity.ContactID, opportunity.AccountID)
+	isClosedStage := opportunity.Stage == OpportunityStageClosedWon || opportunity.Stage == OpportunityStageClosedLost
+	stageBecameClosed := !previousWasClosed && isClosedStage
+
+	if opportunity.CloseReason != "" {
+		opportunity.CloseReason = strings.TrimSpace(opportunity.CloseReason)
+	}
+
+	if stageBecameClosed {
+		if opportunity.ClosedAt == nil {
+			now := time.Now().UTC()
+			opportunity.ClosedAt = &now
+		}
+
+		if opportunity.ClosedByEmployeeID == nil && opportunity.OwnerEmployeeID != nil {
+			opportunity.ClosedByEmployeeID = opportunity.OwnerEmployeeID
+		}
+	} else if previousWasClosed && !isClosedStage {
+		opportunity.ClosedAt = nil
+		opportunity.CloseReason = ""
+		opportunity.ClosedByEmployeeID = nil
+	}
+
+	if opportunity.Stage == OpportunityStageClosedLost {
+		if opportunity.CloseReason == "" {
+			return fmt.Errorf("close reason is required when opportunity is Closed Lost")
+		}
 	}
 
 	return nil

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,11 +9,16 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 0,
 })
 
+const CLOSED_WON_STAGE = 6
+const CLOSED_LOST_STAGE = 7
+
+const isClosedStage = (stage: number) => stage === CLOSED_WON_STAGE || stage === CLOSED_LOST_STAGE
+
 const getStageBadgeClass = (stage: number) => {
   switch (stage) {
-    case 6:
+    case CLOSED_WON_STAGE:
       return 'badge-success'
-    case 7:
+    case CLOSED_LOST_STAGE:
       return 'badge-error'
     case 5:
       return 'badge-warning'
@@ -63,7 +68,7 @@ export default function Dashboard() {
   })
 
   const opportunities = (opportunitiesData?.items as Opportunity[]) || []
-  const openOpportunities = opportunities.filter(opportunity => opportunity.Stage !== 7)
+  const openOpportunities = opportunities.filter(opportunity => !isClosedStage(opportunity.Stage))
   const totalOpenPipeline = openOpportunities.reduce((sum, opportunity) => sum + opportunity.Amount, 0)
 
   const stageOptions = OPPORTUNITY_STAGES()
@@ -71,7 +76,7 @@ export default function Dashboard() {
     .map(stage => ({
       stage,
       total: opportunities
-        .filter(opportunity => opportunity.Stage === stage.value && stage.value !== 7)
+        .filter(opportunity => opportunity.Stage === stage.value && !isClosedStage(stage.value))
         .reduce((sum, opportunity) => sum + opportunity.Amount, 0),
     }))
     .filter(item => item.total > 0)
@@ -85,7 +90,7 @@ export default function Dashboard() {
         return false
       }
       const closeDate = new Date(opportunity.ExpectedCloseDate)
-      return closeDate >= now && closeDate <= horizon && opportunity.Stage < 6
+      return closeDate >= now && closeDate <= horizon && !isClosedStage(opportunity.Stage)
     })
     .sort((a, b) => new Date(a.ExpectedCloseDate || '').getTime() - new Date(b.ExpectedCloseDate || '').getTime())
     .slice(0, 5)

--- a/frontend/src/pages/Opportunities/OpportunityDetail.tsx
+++ b/frontend/src/pages/Opportunities/OpportunityDetail.tsx
@@ -11,11 +11,14 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 0,
 })
 
+const CLOSED_WON_STAGE = 6
+const CLOSED_LOST_STAGE = 7
+
 const getStageBadgeClass = (stage: number) => {
   switch (stage) {
-    case 6:
+    case CLOSED_WON_STAGE:
       return 'badge-success'
-    case 7:
+    case CLOSED_LOST_STAGE:
       return 'badge-error'
     case 5:
       return 'badge-warning'
@@ -40,7 +43,7 @@ export default function OpportunityDetail() {
   const { data: opportunity, isLoading, error } = useQuery({
     queryKey: ['opportunity', id],
     queryFn: async () => {
-      const response = await api.get(`/Opportunities(${id})?$expand=Account,Contact,Owner`)
+      const response = await api.get(`/Opportunities(${id})?$expand=Account,Contact,Owner,ClosedBy`)
       return response.data as Opportunity
     },
   })
@@ -93,6 +96,11 @@ export default function OpportunityDetail() {
             <span className="text-sm text-gray-600 dark:text-gray-400">
               Expected close: {formatDate(opportunity.ExpectedCloseDate)}
             </span>
+            {(opportunity.Stage === CLOSED_WON_STAGE || opportunity.Stage === CLOSED_LOST_STAGE) && (
+              <span className="text-sm text-gray-600 dark:text-gray-400">
+                Closed on: {formatDate(opportunity.ClosedAt)}
+              </span>
+            )}
           </div>
         </div>
         <div className="flex gap-3">
@@ -153,6 +161,38 @@ export default function OpportunityDetail() {
                 {opportunityStageToString(opportunity.Stage)}
               </dd>
             </div>
+            {(opportunity.Stage === CLOSED_WON_STAGE || opportunity.Stage === CLOSED_LOST_STAGE) && (
+              <>
+                <div>
+                  <dt className="text-gray-600 dark:text-gray-400">Closed On</dt>
+                  <dd className="text-gray-900 dark:text-gray-100">
+                    {formatDate(opportunity.ClosedAt)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-600 dark:text-gray-400">Close Reason</dt>
+                  <dd className="text-gray-900 dark:text-gray-100">
+                    {opportunity.CloseReason && opportunity.CloseReason.trim() !== ''
+                      ? opportunity.CloseReason
+                      : 'Not provided'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-gray-600 dark:text-gray-400">Closed By</dt>
+                  <dd className="text-gray-900 dark:text-gray-100">
+                    {opportunity.ClosedBy ? (
+                      <Link to={`/employees/${opportunity.ClosedBy.ID}`} className="text-primary-600 hover:underline">
+                        {opportunity.ClosedBy.FirstName} {opportunity.ClosedBy.LastName}
+                      </Link>
+                    ) : opportunity.ClosedByEmployeeID ? (
+                      `Employee #${opportunity.ClosedByEmployeeID}`
+                    ) : (
+                      'Not recorded'
+                    )}
+                  </dd>
+                </div>
+              </>
+            )}
             <div>
               <dt className="text-gray-600 dark:text-gray-400">Amount</dt>
               <dd className="text-gray-900 dark:text-gray-100">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,11 +105,15 @@ export interface Opportunity {
   ExpectedCloseDate?: string
   Stage: number
   Description?: string
+  ClosedAt?: string
+  CloseReason?: string
+  ClosedByEmployeeID?: number
   CreatedAt: string
   UpdatedAt: string
   Account?: Account
   Contact?: Contact
   Owner?: Employee
+  ClosedBy?: Employee
 }
 
 // Re-export enum utilities from lib/enums


### PR DESCRIPTION
## Summary
- add closed opportunity metadata fields with validation to the Go model and AutoMigrate
- seed realistic closed won/lost records and expose the closer navigation link
- surface close date, reason, and closer details in the opportunity UI and adjust dashboard metrics

## Testing
- `go test ./...` *(fails: unable to download github.com/golang-jwt/jwt due to network restrictions)*
- `npm run lint` *(fails: existing react-refresh warning in src/contexts/AuthContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6904bb0654c0832889aff63c318cee5b