### PR TITLE
Add opportunity line item support across CRM

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -124,6 +124,10 @@ func main() {
 		log.Fatal("Failed to register Opportunity entity:", err)
 	}
 
+	if err := service.RegisterEntity(&models.OpportunityLineItem{}); err != nil {
+		log.Fatal("Failed to register OpportunityLineItem entity:", err)
+	}
+
 	// Register fake authentication action (DEVELOPMENT ONLY)
 	// TODO: Replace with proper authentication provider integration in production
 	if err := registerDevAuthAction(service, db); err != nil {
@@ -153,6 +157,7 @@ func main() {
 	fmt.Println("Activities:        http://localhost:" + port + "/Activities")
 	fmt.Println("Tasks:             http://localhost:" + port + "/Tasks")
 	fmt.Println("Opportunities:     http://localhost:" + port + "/Opportunities")
+	fmt.Println("Opportunity Items: http://localhost:" + port + "/OpportunityLineItems")
 	fmt.Println("Employees:         http://localhost:" + port + "/Employees")
 	fmt.Println("Products:          http://localhost:" + port + "/Products")
 	fmt.Println("========================================")

--- a/backend/models/opportunity_line_item.go
+++ b/backend/models/opportunity_line_item.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"math"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// OpportunityLineItem represents an individual product or service on an opportunity
+type OpportunityLineItem struct {
+	ID              uint      `json:"ID" gorm:"primaryKey" odata:"key"`
+	OpportunityID   uint      `json:"OpportunityID" gorm:"not null;index" odata:"required"`
+	ProductID       uint      `json:"ProductID" gorm:"not null;index" odata:"required"`
+	Quantity        int       `json:"Quantity" gorm:"not null;default:1" odata:"required"`
+	UnitPrice       float64   `json:"UnitPrice" gorm:"not null;type:numeric(12,2)" odata:"required"`
+	DiscountAmount  float64   `json:"DiscountAmount" gorm:"type:numeric(12,2);default:0"`
+	DiscountPercent float64   `json:"DiscountPercent" gorm:"type:numeric(5,2);default:0"`
+	Subtotal        float64   `json:"Subtotal" gorm:"not null;type:numeric(12,2);default:0"`
+	Total           float64   `json:"Total" gorm:"not null;type:numeric(12,2);default:0"`
+	CreatedAt       time.Time `json:"CreatedAt" gorm:"autoCreateTime"`
+	UpdatedAt       time.Time `json:"UpdatedAt" gorm:"autoUpdateTime"`
+
+	Opportunity *Opportunity `json:"Opportunity" gorm:"foreignKey:OpportunityID" odata:"navigation"`
+	Product     *Product     `json:"Product" gorm:"foreignKey:ProductID" odata:"navigation"`
+}
+
+// TableName specifies the table name for GORM
+func (OpportunityLineItem) TableName() string {
+	return "opportunity_line_items"
+}
+
+// BeforeSave calculates subtotal and total values before persisting the record
+func (item *OpportunityLineItem) BeforeSave(tx *gorm.DB) error {
+	if item.Quantity <= 0 {
+		item.Quantity = 1
+	}
+
+	subtotal := float64(item.Quantity) * item.UnitPrice
+	percentDiscount := subtotal * (item.DiscountPercent / 100)
+	totalDiscount := math.Min(subtotal, math.Max(0, item.DiscountAmount+percentDiscount))
+	total := subtotal - totalDiscount
+
+	// Guard against negative values due to rounding or extreme discounts
+	if total < 0 {
+		total = 0
+	}
+
+	item.Subtotal = math.Round(subtotal*100) / 100
+	item.Total = math.Round(total*100) / 100
+
+	return nil
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -125,6 +125,22 @@ export interface Opportunity {
   Contact?: Contact
   Owner?: Employee
   ClosedBy?: Employee
+  LineItems?: OpportunityLineItem[]
+}
+
+export interface OpportunityLineItem {
+  ID: number
+  OpportunityID: number
+  ProductID: number
+  Quantity: number
+  UnitPrice: number
+  DiscountAmount: number
+  DiscountPercent: number
+  Subtotal: number
+  Total: number
+  CreatedAt: string
+  UpdatedAt: string
+  Product?: Product
 }
 
 // Re-export enum utilities from lib/enums


### PR DESCRIPTION
## Summary
- add a dedicated OpportunityLineItem model with total calculations and attach it to opportunities
- migrate, register, and seed the new entity so line items are available through the OData service
- update frontend types plus the opportunity detail and form screens to view and manage nested line items

## Testing
- npm run lint *(fails: react-refresh warning in AuthContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6904baf869b48328b2743cc93fdb7bac