### PR TITLE
Add lead management workflows

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -43,6 +43,7 @@ func AutoMigrate(db *gorm.DB) error {
 	err := db.AutoMigrate(
 		&models.Account{},
 		&models.Contact{},
+		&models.Lead{},
 		&models.Issue{},
 		&models.IssueUpdate{},
 		&models.Activity{},
@@ -587,6 +588,99 @@ func SeedData(db *gorm.DB) error {
 	if len(tasks) > 0 {
 		if err := db.Create(&tasks).Error; err != nil {
 			return fmt.Errorf("failed to create tasks: %w", err)
+		}
+	}
+
+	// Create sample leads representing prospects awaiting conversion
+	leads := []models.Lead{
+		{
+			Name:    "Megan Rivers",
+			Email:   "megan.rivers@greenretail.io",
+			Phone:   "+1-555-3401",
+			Company: "Green Retail Co",
+			Title:   "Operations Director",
+			Website: "https://www.greenretail.io",
+			Source:  "Website",
+			Status:  models.LeadStatusNew,
+			Notes:   "Interested in centralizing customer activity tracking across new store locations.",
+		},
+		{
+			Name:    "Adrian Cole",
+			Email:   "adrian.cole@skyship.ai",
+			Phone:   "+1-555-7821",
+			Company: "Skyship AI",
+			Title:   "Head of Revenue",
+			Website: "https://skyship.ai",
+			Source:  "Referral",
+			Status:  models.LeadStatusContacted,
+			Notes:   "Requested a follow-up demo highlighting AI-powered forecasting.",
+		},
+		{
+			Name:    "Priya Desai",
+			Email:   "priya.desai@orbitlogistics.com",
+			Phone:   "+1-555-2294",
+			Company: "Orbit Logistics",
+			Title:   "IT Program Manager",
+			Website: "https://orbitlogistics.com",
+			Source:  "Conference",
+			Status:  models.LeadStatusQualified,
+			Notes:   "Budget approved for Q3 rollout if integrations look feasible.",
+		},
+		{
+			Name:    "Marcus Lee",
+			Email:   "marcus.lee@apexlabs.org",
+			Phone:   "+1-555-9152",
+			Company: "Apex Research Labs",
+			Title:   "Innovation Lead",
+			Source:  "Inbound Call",
+			Status:  models.LeadStatusContacted,
+			Notes:   "Evaluating CRM platforms that support strict compliance auditing.",
+		},
+		{
+			Name:    "Sofia Hernandez",
+			Email:   "sofia.hernandez@lumenenergy.co",
+			Phone:   "+1-555-6638",
+			Company: "Lumen Energy Cooperative",
+			Title:   "Customer Programs Manager",
+			Source:  "Webinar",
+			Status:  models.LeadStatusNew,
+			Notes:   "Needs better segmentation tools to drive renewable adoption campaigns.",
+		},
+		{
+			Name:    "Jonah Patel",
+			Email:   "jonah.patel@urbanwellness.studio",
+			Phone:   "+1-555-4459",
+			Company: "Urban Wellness Studio",
+			Title:   "Founder",
+			Source:  "Social Media",
+			Status:  models.LeadStatusQualified,
+			Notes:   "Expanding locations and seeking automated nurture journeys.",
+		},
+		{
+			Name:    "Helena Griggs",
+			Email:   "helena.griggs@northwindmarine.com",
+			Phone:   "+1-555-7810",
+			Company: "Northwind Marine",
+			Title:   "Sales Enablement Director",
+			Source:  "Partner",
+			Status:  models.LeadStatusContacted,
+			Notes:   "Comparing vendors; wants integrated quoting workflow demo.",
+		},
+		{
+			Name:    "Damien Cho",
+			Email:   "damien.cho@terrafoods.co",
+			Phone:   "+1-555-2744",
+			Company: "Terra Foods Cooperative",
+			Title:   "Business Development",
+			Source:  "Website",
+			Status:  models.LeadStatusNew,
+			Notes:   "Requested sample dashboards; heavy emphasis on analytics.",
+		},
+	}
+
+	for i := range leads {
+		if err := db.Create(&leads[i]).Error; err != nil {
+			return fmt.Errorf("failed to create lead: %w", err)
 		}
 	}
 

--- a/backend/models/lead.go
+++ b/backend/models/lead.go
@@ -1,0 +1,41 @@
+package models
+
+import "time"
+
+// LeadStatus represents the lifecycle status of a lead
+type LeadStatus string
+
+const (
+	LeadStatusNew          LeadStatus = "New"
+	LeadStatusContacted    LeadStatus = "Contacted"
+	LeadStatusQualified    LeadStatus = "Qualified"
+	LeadStatusConverted    LeadStatus = "Converted"
+	LeadStatusDisqualified LeadStatus = "Disqualified"
+)
+
+// Lead captures prospect information before conversion to an account/contact
+type Lead struct {
+	ID                 uint       `json:"ID" gorm:"primaryKey" odata:"key"`
+	Name               string     `json:"Name" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
+	Email              string     `json:"Email" gorm:"type:varchar(255)" odata:"maxlength(255)"`
+	Phone              string     `json:"Phone" gorm:"type:varchar(50)" odata:"maxlength(50)"`
+	Company            string     `json:"Company" gorm:"type:varchar(255)" odata:"maxlength(255)"`
+	Title              string     `json:"Title" gorm:"type:varchar(150)" odata:"maxlength(150)"`
+	Website            string     `json:"Website" gorm:"type:varchar(255)" odata:"maxlength(255)"`
+	Source             string     `json:"Source" gorm:"type:varchar(100)" odata:"maxlength(100)"`
+	Status             LeadStatus `json:"Status" gorm:"type:varchar(50);default:'New'" odata:"maxlength(50)"`
+	Notes              string     `json:"Notes" gorm:"type:text"`
+	ConvertedAccountID *uint      `json:"ConvertedAccountID" gorm:"index"`
+	ConvertedContactID *uint      `json:"ConvertedContactID" gorm:"index"`
+	ConvertedAt        *time.Time `json:"ConvertedAt"`
+	CreatedAt          time.Time  `json:"CreatedAt" gorm:"autoCreateTime"`
+	UpdatedAt          time.Time  `json:"UpdatedAt" gorm:"autoUpdateTime"`
+
+	ConvertedAccount *Account `json:"ConvertedAccount" gorm:"foreignKey:ConvertedAccountID" odata:"navigation"`
+	ConvertedContact *Contact `json:"ConvertedContact" gorm:"foreignKey:ConvertedContactID" odata:"navigation"`
+}
+
+// TableName specifies the table name for GORM
+func (Lead) TableName() string {
+	return "leads"
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,9 @@ import Dashboard from './pages/Dashboard'
 import AccountsList from './pages/Accounts/AccountsList'
 import AccountDetail from './pages/Accounts/AccountDetail'
 import AccountForm from './pages/Accounts/AccountForm'
+import LeadsList from './pages/Leads/LeadsList'
+import LeadDetail from './pages/Leads/LeadDetail'
+import LeadForm from './pages/Leads/LeadForm'
 import ContactsList from './pages/Contacts/ContactsList'
 import ContactDetail from './pages/Contacts/ContactDetail'
 import ContactForm from './pages/Contacts/ContactForm'
@@ -54,6 +57,12 @@ function App() {
             <Route path="accounts/new" element={<AccountForm />} />
             <Route path="accounts/:id" element={<AccountDetail />} />
             <Route path="accounts/:id/edit" element={<AccountForm />} />
+
+            {/* Leads routes */}
+            <Route path="leads" element={<LeadsList />} />
+            <Route path="leads/new" element={<LeadForm />} />
+            <Route path="leads/:id" element={<LeadDetail />} />
+            <Route path="leads/:id/edit" element={<LeadForm />} />
 
             {/* Contacts routes */}
             <Route path="contacts" element={<ContactsList />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,7 @@ export default function Layout() {
 
   const navigation = [
     { name: 'Accounts', href: '/accounts' },
+    { name: 'Leads', href: '/leads' },
     { name: 'Contacts', href: '/contacts' },
     { name: 'Activities', href: '/activities' },
     { name: 'Issues', href: '/issues' },

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
-import { useAuth } from '../contexts/AuthContext'
+import { useAuth } from '../hooks/useAuth'
 import { Button } from './ui'
 
 export default function Layout() {

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { Navigate } from 'react-router-dom'
-import { useAuth } from '../contexts/AuthContext'
+import { useAuth } from '../hooks/useAuth'
 
 interface ProtectedRouteProps {
   children: React.ReactNode

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from 'react'
+import { createContext, useState, ReactNode } from 'react'
 import api from '../lib/api'
 
 /**
@@ -31,6 +31,8 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export { AuthContext }
 
 interface AuthProviderProps {
   children: ReactNode
@@ -80,12 +82,4 @@ export function AuthProvider({ children }: AuthProviderProps) {
       {children}
     </AuthContext.Provider>
   )
-}
-
-export function useAuth() {
-  const context = useContext(AuthContext)
-  if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider')
-  }
-  return context
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext } from '../contexts/AuthContext'
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/lib/hooks/leads.ts
+++ b/frontend/src/lib/hooks/leads.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../api'
+import { mergeODataQuery } from '../odataUtils'
+import type { Lead } from '../../types'
+
+type LeadPayload = Partial<Pick<Lead,
+  | 'Name'
+  | 'Email'
+  | 'Phone'
+  | 'Company'
+  | 'Title'
+  | 'Website'
+  | 'Source'
+  | 'Status'
+  | 'Notes'
+>>
+
+export const leadKeys = {
+  all: ['leads'] as const,
+  list: (query: string) => ['leads', query] as const,
+  detail: (id: string | number) => ['lead', id] as const,
+}
+
+export function useLeads(query: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: leadKeys.list(query),
+    queryFn: async () => {
+      const response = await api.get(`/Leads${query}`)
+      return response.data
+    },
+    enabled: options?.enabled ?? true,
+  })
+}
+
+export function useLead(id?: string, expand?: string) {
+  return useQuery({
+    queryKey: leadKeys.detail(id ?? 'new'),
+    queryFn: async () => {
+      const expandQuery = expand ? mergeODataQuery('', { '$expand': expand }) : ''
+      const response = await api.get(`/Leads(${id})${expandQuery}`)
+      return response.data as Lead
+    },
+    enabled: Boolean(id),
+  })
+}
+
+export function useLeadMutation(id?: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: LeadPayload) => {
+      if (id) {
+        return api.patch(`/Leads(${id})`, payload)
+      }
+      return api.post('/Leads', payload)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: leadKeys.all })
+      if (id) {
+        queryClient.invalidateQueries({ queryKey: leadKeys.detail(id) })
+      }
+    },
+  })
+}
+
+export function useDeleteLead(id: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      await api.delete(`/Leads(${id})`)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: leadKeys.all })
+    },
+  })
+}
+
+export function useConvertLead(id: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload?: { AccountName?: string }) => {
+      const body = payload ?? {}
+      const response = await api.post(`/Leads(${id})/CRM.ConvertLead`, body)
+      return response.data as { LeadID: number; AccountID: number; ContactID: number }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: leadKeys.all })
+      queryClient.invalidateQueries({ queryKey: leadKeys.detail(id) })
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      queryClient.invalidateQueries({ queryKey: ['contacts'] })
+    },
+  })
+}
+
+export function buildLeadQuery(searchQuery: string, extraParams?: Record<string, string>) {
+  return mergeODataQuery(searchQuery, {
+    $count: 'true',
+    $expand: 'ConvertedAccount,ConvertedContact',
+    ...extraParams,
+  })
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -48,6 +48,14 @@ export default function Dashboard() {
     },
   })
 
+  const { data: leadsData, isLoading: leadsLoading, error: leadsError } = useQuery({
+    queryKey: ['leads-active-count'],
+    queryFn: async () => {
+      const response = await api.get("/Leads?$filter=Status ne 'Converted' and Status ne 'Disqualified'&$count=true&$top=0")
+      return response.data
+    },
+  })
+
   // Fetch open issues count (exclude Closed and Resolved)
   // Status values: 1=New, 2=InProgress, 3=Pending, 4=Resolved, 5=Closed
   const { data: issuesData, isLoading: issuesLoading, error: issuesError } = useQuery({
@@ -95,8 +103,8 @@ export default function Dashboard() {
     .sort((a, b) => new Date(a.ExpectedCloseDate || '').getTime() - new Date(b.ExpectedCloseDate || '').getTime())
     .slice(0, 5)
 
-  const isLoading = accountsLoading || contactsLoading || issuesLoading || opportunitiesLoading
-  const hasError = accountsError || contactsError || issuesError || opportunitiesError
+  const isLoading = accountsLoading || contactsLoading || leadsLoading || issuesLoading || opportunitiesLoading
+  const hasError = accountsError || contactsError || leadsError || issuesError || opportunitiesError
 
   return (
     <div className="space-y-6">
@@ -116,7 +124,17 @@ export default function Dashboard() {
       )}
 
       {/* Stats cards */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-6">
+        <div className="card p-6">
+          <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">Active Leads</h3>
+          <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+            {isLoading ? '...' : leadsData?.count ?? 0}
+          </p>
+          <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+            Excluding converted or disqualified records
+          </p>
+        </div>
+
         <div className="card p-6">
           <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">Total Accounts</h3>
           <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
@@ -154,7 +172,19 @@ export default function Dashboard() {
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
           Quick Actions
         </h2>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4">
+          <Link
+            to="/leads/new"
+            className="btn btn-primary text-center"
+          >
+            Capture Lead
+          </Link>
+          <Link
+            to="/leads"
+            className="btn btn-secondary text-center"
+          >
+            Manage Leads
+          </Link>
           <Link
             to="/accounts/new"
             className="btn btn-primary text-center"

--- a/frontend/src/pages/Leads/LeadDetail.tsx
+++ b/frontend/src/pages/Leads/LeadDetail.tsx
@@ -1,0 +1,255 @@
+import { useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Button, Input } from '../../components/ui'
+import { useConvertLead, useDeleteLead, useLead } from '../../lib/hooks/leads'
+
+interface ConversionResult {
+  accountId: number
+  contactId: number
+}
+
+export default function LeadDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  const [overrideAccountName, setOverrideAccountName] = useState('')
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showConvertOptions, setShowConvertOptions] = useState(false)
+  const [conversionMessage, setConversionMessage] = useState('')
+  const [conversionResult, setConversionResult] = useState<ConversionResult | null>(null)
+
+  if (!id) {
+    return (
+      <div className="text-center py-12 text-error-600 dark:text-error-400">
+        Lead identifier is missing.
+      </div>
+    )
+  }
+
+  const { data: lead, isLoading, error } = useLead(id, 'ConvertedAccount,ConvertedContact')
+  const deleteMutation = useDeleteLead(id)
+  const convertMutation = useConvertLead(id)
+
+  if (isLoading) {
+    return <div className="text-center py-12 text-gray-600 dark:text-gray-400">Loading lead...</div>
+  }
+
+  if (error || !lead) {
+    return (
+      <div className="text-center py-12 text-error-600 dark:text-error-400">
+        Unable to load lead details.
+      </div>
+    )
+  }
+
+  const isConverted = lead.Status === 'Converted' || Boolean(lead.ConvertedAccountID)
+
+  const handleDelete = () => {
+    deleteMutation.mutate(undefined, {
+      onSuccess: () => navigate('/leads'),
+    })
+  }
+
+  const handleConvert = () => {
+    convertMutation.mutate(
+      overrideAccountName ? { AccountName: overrideAccountName } : undefined,
+      {
+        onSuccess: (data) => {
+          setConversionMessage('Lead converted successfully.')
+          setConversionResult({ accountId: data.AccountID, contactId: data.ContactID })
+          setOverrideAccountName('')
+          setShowConvertOptions(false)
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">{lead.Name}</h1>
+            <span className={`badge ${isConverted ? 'badge-success' : 'badge-secondary'}`}>{lead.Status}</span>
+          </div>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Captured {new Date(lead.CreatedAt).toLocaleString()}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Link to={`/leads/${id}/edit`} className="btn btn-primary">
+            Edit Lead
+          </Link>
+          {!isConverted && (
+            <Button variant="secondary" onClick={() => setShowConvertOptions((prev) => !prev)}>
+              {showConvertOptions ? 'Cancel Convert' : 'Convert Lead'}
+            </Button>
+          )}
+          <Button variant="danger" onClick={() => setShowDeleteConfirm(true)}>
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      {(conversionMessage || conversionResult) && (
+        <div className="card border border-success-200 dark:border-success-800 bg-success-50/80 dark:bg-success-900/10 p-4 space-y-2">
+          {conversionMessage && (
+            <p className="text-success-700 dark:text-success-300">{conversionMessage}</p>
+          )}
+          {conversionResult && (
+            <p className="text-sm text-success-700 dark:text-success-300">
+              Account{' '}
+              <Link to={`/accounts/${conversionResult.accountId}`} className="text-primary-600 hover:underline">
+                #{conversionResult.accountId}
+              </Link>{' '}
+              and contact{' '}
+              <Link to={`/contacts/${conversionResult.contactId}`} className="text-primary-600 hover:underline">
+                #{conversionResult.contactId}
+              </Link>{' '}
+              were created from this lead.
+            </p>
+          )}
+        </div>
+      )}
+
+      {showConvertOptions && !isConverted && (
+        <div className="card p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Convert to Account &amp; Contact</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Optionally override the account name before conversion. Leave blank to reuse the lead company or name.
+            </p>
+          </div>
+          <Input
+            label="Account Name Override"
+            placeholder={lead.Company || lead.Name}
+            value={overrideAccountName}
+            onChange={(event) => setOverrideAccountName(event.target.value)}
+          />
+          <div className="flex flex-wrap gap-3">
+            <Button variant="primary" onClick={handleConvert} disabled={convertMutation.isPending}>
+              {convertMutation.isPending ? 'Converting...' : 'Convert Lead'}
+            </Button>
+            <Button variant="secondary" onClick={() => setShowConvertOptions(false)} disabled={convertMutation.isPending}>
+              Cancel
+            </Button>
+          </div>
+          {convertMutation.error && (
+            <p className="text-sm text-error-600 dark:text-error-400">
+              {(convertMutation.error as Error).message || 'Unable to convert lead.'}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="card p-6 lg:col-span-2 space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Lead Details</h2>
+          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {lead.Company && (
+              <div>
+                <dt className="text-sm font-medium text-gray-600 dark:text-gray-400">Company</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">{lead.Company}</dd>
+              </div>
+            )}
+            {lead.Title && (
+              <div>
+                <dt className="text-sm font-medium text-gray-600 dark:text-gray-400">Title</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">{lead.Title}</dd>
+              </div>
+            )}
+            {lead.Email && (
+              <div>
+                <dt className="text-sm font-medium text-gray-600 dark:text-gray-400">Email</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">
+                  <a href={`mailto:${lead.Email}`} className="text-primary-600 hover:underline">
+                    {lead.Email}
+                  </a>
+                </dd>
+              </div>
+            )}
+            {lead.Phone && (
+              <div>
+                <dt className="text-sm font-medium text-gray-600 dark:text-gray-400">Phone</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">{lead.Phone}</dd>
+              </div>
+            )}
+            {lead.Website && (
+              <div>
+                <dt className="text-sm font-medium text-gray-600 dark:text-gray-400">Website</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">
+                  <a href={lead.Website} target="_blank" rel="noreferrer" className="text-primary-600 hover:underline">
+                    {lead.Website}
+                  </a>
+                </dd>
+              </div>
+            )}
+            {lead.Source && (
+              <div>
+                <dt className="text-sm font-medium text-gray-600 dark:text-gray-400">Source</dt>
+                <dd className="text-sm text-gray-900 dark:text-gray-100">{lead.Source}</dd>
+              </div>
+            )}
+          </dl>
+          {lead.Notes && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">Notes</h3>
+              <p className="text-sm text-gray-900 dark:text-gray-100 whitespace-pre-wrap">{lead.Notes}</p>
+            </div>
+          )}
+        </div>
+
+        <div className="card p-6 space-y-3">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Conversion Status</h2>
+          <div className="text-sm text-gray-600 dark:text-gray-400 space-y-2">
+            <div>
+              Status:{' '}
+              <span className="font-medium text-gray-900 dark:text-gray-100">{lead.Status}</span>
+            </div>
+            {lead.ConvertedAt && (
+              <div>Converted: {new Date(lead.ConvertedAt).toLocaleString()}</div>
+            )}
+            {lead.ConvertedAccount && (
+              <div>
+                Account:{' '}
+                <Link to={`/accounts/${lead.ConvertedAccount.ID}`} className="text-primary-600 hover:underline">
+                  {lead.ConvertedAccount.Name}
+                </Link>
+              </div>
+            )}
+            {lead.ConvertedContact && (
+              <div>
+                Contact:{' '}
+                <Link to={`/contacts/${lead.ConvertedContact.ID}`} className="text-primary-600 hover:underline">
+                  {lead.ConvertedContact.FirstName} {lead.ConvertedContact.LastName}
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showDeleteConfirm && (
+        <div className="card border border-error-200 dark:border-error-800 bg-error-50/80 dark:bg-error-900/10 p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-error-600 dark:text-error-400">Delete Lead</h2>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            Are you sure you want to delete this lead? This action cannot be undone.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Button variant="danger" onClick={handleDelete} disabled={deleteMutation.isPending}>
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete Lead'}
+            </Button>
+            <Button variant="secondary" onClick={() => setShowDeleteConfirm(false)} disabled={deleteMutation.isPending}>
+              Cancel
+            </Button>
+          </div>
+          {deleteMutation.error && (
+            <p className="text-sm text-error-600 dark:text-error-400">
+              {(deleteMutation.error as Error).message || 'Failed to delete lead.'}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Leads/LeadDetail.tsx
+++ b/frontend/src/pages/Leads/LeadDetail.tsx
@@ -18,6 +18,11 @@ export default function LeadDetail() {
   const [conversionMessage, setConversionMessage] = useState('')
   const [conversionResult, setConversionResult] = useState<ConversionResult | null>(null)
 
+  // Always call hooks before any conditional returns
+  const { data: lead, isLoading, error } = useLead(id, 'ConvertedAccount,ConvertedContact')
+  const deleteMutation = useDeleteLead(id || '')
+  const convertMutation = useConvertLead(id || '')
+
   if (!id) {
     return (
       <div className="text-center py-12 text-error-600 dark:text-error-400">
@@ -25,10 +30,6 @@ export default function LeadDetail() {
       </div>
     )
   }
-
-  const { data: lead, isLoading, error } = useLead(id, 'ConvertedAccount,ConvertedContact')
-  const deleteMutation = useDeleteLead(id)
-  const convertMutation = useConvertLead(id)
 
   if (isLoading) {
     return <div className="text-center py-12 text-gray-600 dark:text-gray-400">Loading lead...</div>

--- a/frontend/src/pages/Leads/LeadForm.tsx
+++ b/frontend/src/pages/Leads/LeadForm.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Button, Input, Textarea } from '../../components/ui'
+import { useLead, useLeadMutation } from '../../lib/hooks/leads'
+import type { Lead, LeadStatus } from '../../types'
+
+const STATUS_OPTIONS: LeadStatus[] = ['New', 'Contacted', 'Qualified', 'Converted', 'Disqualified']
+
+type LeadFormState = Partial<Pick<Lead, 'Name' | 'Email' | 'Phone' | 'Company' | 'Title' | 'Website' | 'Source' | 'Status' | 'Notes'>>
+
+const EMPTY_FORM: LeadFormState = {
+  Name: '',
+  Email: '',
+  Phone: '',
+  Company: '',
+  Title: '',
+  Website: '',
+  Source: '',
+  Status: 'New',
+  Notes: '',
+}
+
+export default function LeadForm() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const isEdit = Boolean(id)
+
+  const { data: lead } = useLead(id)
+  const mutation = useLeadMutation(id)
+
+  const initialFormState = useMemo(() => {
+    if (lead) {
+      return {
+        Name: lead.Name,
+        Email: lead.Email || '',
+        Phone: lead.Phone || '',
+        Company: lead.Company || '',
+        Title: lead.Title || '',
+        Website: lead.Website || '',
+        Source: lead.Source || '',
+        Status: lead.Status,
+        Notes: lead.Notes || '',
+      }
+    }
+    return { ...EMPTY_FORM }
+  }, [lead])
+
+  const [formData, setFormData] = useState<LeadFormState>(initialFormState)
+
+  useEffect(() => {
+    setFormData(initialFormState)
+  }, [initialFormState])
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    mutation.mutate(formData, {
+      onSuccess: () => {
+        navigate(isEdit ? `/leads/${id}` : '/leads')
+      },
+    })
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          {isEdit ? 'Edit Lead' : 'Capture Lead'}
+        </h1>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">
+          Keep track of new prospects and convert them when they are ready.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="card p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <Input
+            label="Lead Name"
+            name="Name"
+            value={formData.Name}
+            onChange={handleChange}
+            required
+          />
+
+          <Input
+            label="Company"
+            name="Company"
+            value={formData.Company}
+            onChange={handleChange}
+          />
+
+          <Input
+            label="Title"
+            name="Title"
+            value={formData.Title}
+            onChange={handleChange}
+          />
+
+          <Input
+            label="Email"
+            name="Email"
+            type="email"
+            value={formData.Email}
+            onChange={handleChange}
+          />
+
+          <Input
+            label="Phone"
+            name="Phone"
+            value={formData.Phone}
+            onChange={handleChange}
+          />
+
+          <Input
+            label="Website"
+            name="Website"
+            type="url"
+            value={formData.Website}
+            onChange={handleChange}
+          />
+
+          <Input
+            label="Source"
+            name="Source"
+            value={formData.Source}
+            onChange={handleChange}
+          />
+
+          <div>
+            <label htmlFor="Status" className="label">
+              Status
+            </label>
+            <select
+              id="Status"
+              name="Status"
+              value={formData.Status}
+              onChange={handleChange}
+              className="input"
+            >
+              {STATUS_OPTIONS.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <Textarea
+          label="Notes"
+          name="Notes"
+          value={formData.Notes}
+          onChange={handleChange}
+          rows={4}
+        />
+
+        <div className="flex flex-wrap gap-3 justify-end">
+          <Button type="button" variant="secondary" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" disabled={mutation.isPending}>
+            {mutation.isPending ? (isEdit ? 'Updating...' : 'Saving...') : isEdit ? 'Update Lead' : 'Save Lead'}
+          </Button>
+        </div>
+
+        {mutation.error && (
+          <p className="text-sm text-error-600 dark:text-error-400">
+            {(mutation.error as Error).message || 'Failed to save lead.'}
+          </p>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/Leads/LeadsList.tsx
+++ b/frontend/src/pages/Leads/LeadsList.tsx
@@ -1,0 +1,160 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import EntitySearch, { PaginationControls } from '../../components/EntitySearch'
+import type { Lead } from '../../types'
+import { buildLeadQuery, useLeads } from '../../lib/hooks/leads'
+
+const statusBadgeVariant: Record<string, string> = {
+  New: 'badge-primary',
+  Contacted: 'badge-secondary',
+  Qualified: 'badge-warning',
+  Converted: 'badge-success',
+  Disqualified: 'badge-error',
+}
+
+export default function LeadsList() {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+
+  const odataQuery = useMemo(() => buildLeadQuery(searchQuery), [searchQuery])
+
+  const { data, isLoading, error } = useLeads(odataQuery)
+
+  const leads = (data?.items as Lead[]) || []
+  const totalCount = data?.count || 0
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Leads</h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Capture and manage prospects before converting them into accounts.
+          </p>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Link to="/leads/new" className="btn btn-primary text-center">
+            Add Lead
+          </Link>
+          <Link to="/accounts/new" className="btn btn-secondary text-center">
+            New Account from Scratch
+          </Link>
+        </div>
+      </div>
+
+      <EntitySearch
+        searchPlaceholder="Search leads by name, company, or email..."
+        sortOptions={[
+          { label: 'Newest First', value: 'CreatedAt desc' },
+          { label: 'Oldest First', value: 'CreatedAt asc' },
+          { label: 'Name (A-Z)', value: 'Name asc' },
+          { label: 'Name (Z-A)', value: 'Name desc' },
+        ]}
+        filterOptions={[
+          {
+            label: 'Status',
+            key: 'Status',
+            type: 'select',
+            options: [
+              { label: 'New', value: 'New' },
+              { label: 'Contacted', value: 'Contacted' },
+              { label: 'Qualified', value: 'Qualified' },
+              { label: 'Converted', value: 'Converted' },
+              { label: 'Disqualified', value: 'Disqualified' },
+            ],
+          },
+          {
+            label: 'Source',
+            key: 'Source',
+            type: 'text',
+          },
+        ]}
+        onQueryChange={(query) => setSearchQuery(query)}
+        currentPage={currentPage}
+        pageSize={pageSize}
+        onPageChange={setCurrentPage}
+        onPageSizeChange={(size) => {
+          setPageSize(size)
+          setCurrentPage(1)
+        }}
+      />
+
+      {isLoading && (
+        <div className="text-center py-12 text-gray-600 dark:text-gray-400">Loading leads...</div>
+      )}
+
+      {error && (
+        <div className="text-center py-12 text-error-600 dark:text-error-400">
+          Error loading leads: {(error as Error).message}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <>
+          <div className="grid grid-cols-1 gap-4">
+            {leads.map((lead) => {
+              const badgeClass = statusBadgeVariant[lead.Status] ?? 'badge-secondary'
+              return (
+                <Link
+                  key={lead.ID}
+                  to={`/leads/${lead.ID}`}
+                  className="card p-6 hover:shadow-md transition-shadow"
+                >
+                  <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                          {lead.Name}
+                        </h3>
+                        <span className={`badge ${badgeClass}`}>{lead.Status}</span>
+                      </div>
+                      {lead.Company && (
+                        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">{lead.Company}</p>
+                      )}
+                      <div className="mt-3 space-y-1 text-sm text-gray-600 dark:text-gray-400">
+                        {lead.Email && <div>📧 {lead.Email}</div>}
+                        {lead.Phone && <div>📞 {lead.Phone}</div>}
+                        {lead.Source && <div>🗂️ Source: {lead.Source}</div>}
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-2 text-sm text-gray-600 dark:text-gray-400 text-left md:text-right">
+                      <div>Created {new Date(lead.CreatedAt).toLocaleDateString()}</div>
+                      {lead.ConvertedAccountID && lead.ConvertedAccount ? (
+                        <div className="text-success-600 dark:text-success-400">
+                          Converted to {lead.ConvertedAccount.Name}
+                        </div>
+                      ) : (
+                        <div>Not converted</div>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+
+          {leads.length === 0 && (
+            <div className="card p-12 text-center space-y-4">
+              <p className="text-gray-600 dark:text-gray-400">No leads found</p>
+              <Link to="/leads/new" className="btn btn-primary inline-block">
+                Capture your first lead
+              </Link>
+            </div>
+          )}
+
+          <PaginationControls
+            totalCount={totalCount}
+            currentPage={currentPage}
+            pageSize={pageSize}
+            onPageChange={setCurrentPage}
+            onPageSizeChange={(size) => {
+              setPageSize(size)
+              setCurrentPage(1)
+            }}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useAuth } from '../contexts/AuthContext'
+import { useAuth } from '../hooks/useAuth'
 import { Button, Input } from '../components/ui'
 
 /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,28 @@ export interface IssueUpdate {
   Employee?: Employee
 }
 
+export type LeadStatus = 'New' | 'Contacted' | 'Qualified' | 'Converted' | 'Disqualified'
+
+export interface Lead {
+  ID: number
+  Name: string
+  Email?: string
+  Phone?: string
+  Company?: string
+  Title?: string
+  Website?: string
+  Source?: string
+  Status: LeadStatus
+  Notes?: string
+  ConvertedAccountID?: number
+  ConvertedContactID?: number
+  ConvertedAt?: string
+  CreatedAt: string
+  UpdatedAt: string
+  ConvertedAccount?: Account
+  ConvertedContact?: Contact
+}
+
 export interface Issue {
   ID: number
   AccountID: number


### PR DESCRIPTION
## Summary
- add a Lead model with migrations, seed data, and register it in the OData service
- expose a ConvertLead action that turns leads into accounts and contacts
- build React lead list/detail/form pages, hooks, navigation, and dashboard updates

## Testing
- go test ./... *(fails: https://proxy.golang.org/github.com/golang-jwt/jwt/v5/@v/v5.3.0.zip: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6904bb0a774483288e2110dc66cf2995