### PR TITLE
Link opportunity follow-ups across backend and UI

### DIFF
--- a/backend/models/activity.go
+++ b/backend/models/activity.go
@@ -10,22 +10,24 @@ import (
 // Activity represents an interaction or note recorded against an account
 // ActivityTime captures when the interaction took place rather than when it was logged.
 type Activity struct {
-	ID           uint      `json:"ID" gorm:"primaryKey" odata:"key"`
-	AccountID    uint      `json:"AccountID" gorm:"not null;index" odata:"required"`
-	ContactID    *uint     `json:"ContactID" gorm:"index"`
-	EmployeeID   *uint     `json:"EmployeeID" gorm:"index"`
-	ActivityType string    `json:"ActivityType" gorm:"not null;type:varchar(100)" odata:"required,maxlength(100)"`
-	Subject      string    `json:"Subject" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
-	Outcome      string    `json:"Outcome" gorm:"type:varchar(150)" odata:"maxlength(150)"`
-	Notes        string    `json:"Notes" gorm:"type:text"`
-	ActivityTime time.Time `json:"ActivityTime" gorm:"not null" odata:"required"`
-	CreatedAt    time.Time `json:"CreatedAt" gorm:"autoCreateTime"`
-	UpdatedAt    time.Time `json:"UpdatedAt" gorm:"autoUpdateTime"`
+	ID            uint      `json:"ID" gorm:"primaryKey" odata:"key"`
+	AccountID     uint      `json:"AccountID" gorm:"not null;index" odata:"required"`
+	ContactID     *uint     `json:"ContactID" gorm:"index"`
+	EmployeeID    *uint     `json:"EmployeeID" gorm:"index"`
+	OpportunityID *uint     `json:"OpportunityID" gorm:"index"`
+	ActivityType  string    `json:"ActivityType" gorm:"not null;type:varchar(100)" odata:"required,maxlength(100)"`
+	Subject       string    `json:"Subject" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
+	Outcome       string    `json:"Outcome" gorm:"type:varchar(150)" odata:"maxlength(150)"`
+	Notes         string    `json:"Notes" gorm:"type:text"`
+	ActivityTime  time.Time `json:"ActivityTime" gorm:"not null" odata:"required"`
+	CreatedAt     time.Time `json:"CreatedAt" gorm:"autoCreateTime"`
+	UpdatedAt     time.Time `json:"UpdatedAt" gorm:"autoUpdateTime"`
 
 	// Navigation properties
-	Account  *Account  `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
-	Contact  *Contact  `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
-	Employee *Employee `json:"Employee" gorm:"foreignKey:EmployeeID" odata:"navigation"`
+	Account     *Account     `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
+	Contact     *Contact     `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
+	Employee    *Employee    `json:"Employee" gorm:"foreignKey:EmployeeID" odata:"navigation"`
+	Opportunity *Opportunity `json:"Opportunity" gorm:"foreignKey:OpportunityID" odata:"navigation"`
 }
 
 // TableName specifies the table name for GORM
@@ -35,17 +37,26 @@ func (Activity) TableName() string {
 
 // BeforeSave validates relationships before persisting changes
 func (activity *Activity) BeforeSave(tx *gorm.DB) error {
-	if activity.ContactID == nil {
-		return nil
+	if activity.ContactID != nil {
+		var contact Contact
+		if err := tx.Select("account_id").First(&contact, *activity.ContactID).Error; err != nil {
+			return err
+		}
+
+		if contact.AccountID != activity.AccountID {
+			return fmt.Errorf("contact %d does not belong to account %d", *activity.ContactID, activity.AccountID)
+		}
 	}
 
-	var contact Contact
-	if err := tx.Select("account_id").First(&contact, *activity.ContactID).Error; err != nil {
-		return err
-	}
+	if activity.OpportunityID != nil {
+		var opportunity Opportunity
+		if err := tx.Select("account_id").First(&opportunity, *activity.OpportunityID).Error; err != nil {
+			return err
+		}
 
-	if contact.AccountID != activity.AccountID {
-		return fmt.Errorf("contact %d does not belong to account %d", *activity.ContactID, activity.AccountID)
+		if opportunity.AccountID != activity.AccountID {
+			return fmt.Errorf("opportunity %d does not belong to account %d", *activity.OpportunityID, activity.AccountID)
+		}
 	}
 
 	return nil

--- a/backend/models/opportunity.go
+++ b/backend/models/opportunity.go
@@ -65,11 +65,13 @@ type Opportunity struct {
 	UpdatedAt          time.Time        `json:"UpdatedAt" gorm:"autoUpdateTime"`
 
 	// Navigation properties
-	Account   *Account              `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
-	Contact   *Contact              `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
-	Owner     *Employee             `json:"Owner" gorm:"foreignKey:OwnerEmployeeID" odata:"navigation"`
-	ClosedBy  *Employee             `json:"ClosedBy" gorm:"foreignKey:ClosedByEmployeeID" odata:"navigation"`
-	LineItems []OpportunityLineItem `json:"LineItems,omitempty" gorm:"constraint:OnDelete:CASCADE;foreignKey:OpportunityID" odata:"navigation"`
+	Account    *Account              `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
+	Contact    *Contact              `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
+	Owner      *Employee             `json:"Owner" gorm:"foreignKey:OwnerEmployeeID" odata:"navigation"`
+	ClosedBy   *Employee             `json:"ClosedBy" gorm:"foreignKey:ClosedByEmployeeID" odata:"navigation"`
+	LineItems  []OpportunityLineItem `json:"LineItems,omitempty" gorm:"constraint:OnDelete:CASCADE;foreignKey:OpportunityID" odata:"navigation"`
+	Activities []Activity            `json:"Activities,omitempty" gorm:"foreignKey:OpportunityID" odata:"navigation"`
+	Tasks      []Task                `json:"Tasks,omitempty" gorm:"foreignKey:OpportunityID" odata:"navigation"`
 }
 
 // TableName specifies the table name for GORM

--- a/backend/models/task.go
+++ b/backend/models/task.go
@@ -22,23 +22,25 @@ const (
 // Task represents a follow-up item associated with an account
 // Tasks capture accountability with an owner, status and due date.
 type Task struct {
-	ID          uint       `json:"ID" gorm:"primaryKey" odata:"key"`
-	AccountID   uint       `json:"AccountID" gorm:"not null;index" odata:"required"`
-	ContactID   *uint      `json:"ContactID" gorm:"index"`
-	EmployeeID  *uint      `json:"EmployeeID" gorm:"index"`
-	Title       string     `json:"Title" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
-	Description string     `json:"Description" gorm:"type:text"`
-	Owner       string     `json:"Owner" gorm:"not null;type:varchar(150)" odata:"required,maxlength(150)"`
-	Status      TaskStatus `json:"Status" gorm:"not null;type:integer;default:1" odata:"required,enum=TaskStatus"`
-	DueDate     time.Time  `json:"DueDate" gorm:"not null" odata:"required"`
-	CompletedAt *time.Time `json:"CompletedAt"`
-	CreatedAt   time.Time  `json:"CreatedAt" gorm:"autoCreateTime"`
-	UpdatedAt   time.Time  `json:"UpdatedAt" gorm:"autoUpdateTime"`
+	ID            uint       `json:"ID" gorm:"primaryKey" odata:"key"`
+	AccountID     uint       `json:"AccountID" gorm:"not null;index" odata:"required"`
+	ContactID     *uint      `json:"ContactID" gorm:"index"`
+	EmployeeID    *uint      `json:"EmployeeID" gorm:"index"`
+	OpportunityID *uint      `json:"OpportunityID" gorm:"index"`
+	Title         string     `json:"Title" gorm:"not null;type:varchar(255)" odata:"required,maxlength(255)"`
+	Description   string     `json:"Description" gorm:"type:text"`
+	Owner         string     `json:"Owner" gorm:"not null;type:varchar(150)" odata:"required,maxlength(150)"`
+	Status        TaskStatus `json:"Status" gorm:"not null;type:integer;default:1" odata:"required,enum=TaskStatus"`
+	DueDate       time.Time  `json:"DueDate" gorm:"not null" odata:"required"`
+	CompletedAt   *time.Time `json:"CompletedAt"`
+	CreatedAt     time.Time  `json:"CreatedAt" gorm:"autoCreateTime"`
+	UpdatedAt     time.Time  `json:"UpdatedAt" gorm:"autoUpdateTime"`
 
 	// Navigation properties
-	Account  *Account  `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
-	Contact  *Contact  `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
-	Employee *Employee `json:"Employee" gorm:"foreignKey:EmployeeID" odata:"navigation"`
+	Account     *Account     `json:"Account" gorm:"foreignKey:AccountID" odata:"navigation"`
+	Contact     *Contact     `json:"Contact" gorm:"foreignKey:ContactID" odata:"navigation"`
+	Employee    *Employee    `json:"Employee" gorm:"foreignKey:EmployeeID" odata:"navigation"`
+	Opportunity *Opportunity `json:"Opportunity" gorm:"foreignKey:OpportunityID" odata:"navigation"`
 }
 
 // TableName specifies the table name for GORM
@@ -48,17 +50,26 @@ func (Task) TableName() string {
 
 // BeforeSave validates relationships before persisting changes
 func (task *Task) BeforeSave(tx *gorm.DB) error {
-	if task.ContactID == nil {
-		return nil
+	if task.ContactID != nil {
+		var contact Contact
+		if err := tx.Select("account_id").First(&contact, *task.ContactID).Error; err != nil {
+			return err
+		}
+
+		if contact.AccountID != task.AccountID {
+			return fmt.Errorf("contact %d does not belong to account %d", *task.ContactID, task.AccountID)
+		}
 	}
 
-	var contact Contact
-	if err := tx.Select("account_id").First(&contact, *task.ContactID).Error; err != nil {
-		return err
-	}
+	if task.OpportunityID != nil {
+		var opportunity Opportunity
+		if err := tx.Select("account_id").First(&opportunity, *task.OpportunityID).Error; err != nil {
+			return err
+		}
 
-	if contact.AccountID != task.AccountID {
-		return fmt.Errorf("contact %d does not belong to account %d", *task.ContactID, task.AccountID)
+		if opportunity.AccountID != task.AccountID {
+			return fmt.Errorf("opportunity %d does not belong to account %d", *task.OpportunityID, task.AccountID)
+		}
 	}
 
 	return nil

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -97,6 +97,7 @@ export interface Activity {
   AccountID: number
   ContactID?: number
   EmployeeID?: number
+  OpportunityID?: number
   ActivityType: string
   Subject: string
   Outcome?: string
@@ -107,6 +108,7 @@ export interface Activity {
   Account?: Account
   Contact?: Contact
   Employee?: Employee
+  Opportunity?: Opportunity
 }
 
 export interface Task {
@@ -114,6 +116,7 @@ export interface Task {
   AccountID: number
   ContactID?: number
   EmployeeID?: number
+  OpportunityID?: number
   Title: string
   Description?: string
   Owner: string
@@ -125,6 +128,7 @@ export interface Task {
   Account?: Account
   Contact?: Contact
   Employee?: Employee
+  Opportunity?: Opportunity
 }
 
 export interface Opportunity {
@@ -148,6 +152,8 @@ export interface Opportunity {
   Owner?: Employee
   ClosedBy?: Employee
   LineItems?: OpportunityLineItem[]
+  Activities?: Activity[]
+  Tasks?: Task[]
 }
 
 export interface OpportunityLineItem {


### PR DESCRIPTION
## Summary
- add optional opportunity associations to activities and tasks with validation and new seed data
- expose opportunity follow-up relationships through shared types and expanded queries
- refresh opportunity detail and follow-up forms to manage and filter tasks and activities scoped to a deal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905ca69917c8328bd8769c757d047df