### PR TITLE
Support lead-linked activities and tasks

### DIFF
--- a/backend/models/lead.go
+++ b/backend/models/lead.go
@@ -32,9 +32,11 @@ type Lead struct {
 	CreatedAt          time.Time  `json:"CreatedAt" gorm:"autoCreateTime"`
 	UpdatedAt          time.Time  `json:"UpdatedAt" gorm:"autoUpdateTime"`
 
-	ConvertedAccount *Account  `json:"ConvertedAccount" gorm:"foreignKey:ConvertedAccountID" odata:"navigation"`
-	ConvertedContact *Contact  `json:"ConvertedContact" gorm:"foreignKey:ConvertedContactID" odata:"navigation"`
-	OwnerEmployee    *Employee `json:"OwnerEmployee" gorm:"foreignKey:OwnerEmployeeID" odata:"navigation"`
+	ConvertedAccount *Account    `json:"ConvertedAccount" gorm:"foreignKey:ConvertedAccountID" odata:"navigation"`
+	ConvertedContact *Contact    `json:"ConvertedContact" gorm:"foreignKey:ConvertedContactID" odata:"navigation"`
+	OwnerEmployee    *Employee   `json:"OwnerEmployee" gorm:"foreignKey:OwnerEmployeeID" odata:"navigation"`
+	Activities       []*Activity `json:"Activities" gorm:"foreignKey:LeadID" odata:"navigation"`
+	Tasks            []*Task     `json:"Tasks" gorm:"foreignKey:LeadID" odata:"navigation"`
 }
 
 // TableName specifies the table name for GORM

--- a/backend/workflows/engine.go
+++ b/backend/workflows/engine.go
@@ -328,7 +328,7 @@ func (e *Engine) createFollowUpTask(config FollowUpTaskActionConfig, event Event
 	}
 
 	task := models.Task{
-		AccountID:   accountID,
+		AccountID:   &accountID,
 		Title:       config.Title,
 		Description: config.Description,
 		Owner:       config.Owner,

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 import type { Task } from '../types'
 import { taskStatusToString } from '../types'
 
@@ -59,6 +60,22 @@ export default function TaskList({ tasks, emptyMessage = 'No tasks assigned', re
               </span>
             </div>
           </div>
+          {task.Account && task.AccountID && (
+            <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+              Account:{' '}
+              <Link to={`/accounts/${task.AccountID}`} className="text-primary-600 hover:underline">
+                {task.Account.Name}
+              </Link>
+            </div>
+          )}
+          {task.Lead && task.LeadID && (
+            <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+              Lead:{' '}
+              <Link to={`/leads/${task.LeadID}`} className="text-primary-600 hover:underline">
+                {task.Lead.Name}
+              </Link>
+            </div>
+          )}
           {task.Contact && (
             <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">
               Contact: {task.Contact.FirstName} {task.Contact.LastName}

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 import type { Activity } from '../types'
 
 interface TimelineProps {
@@ -41,6 +42,22 @@ export default function Timeline({ activities, emptyMessage = 'No activity yet',
                   <div className="font-medium text-gray-700 dark:text-gray-300">
                     {activity.ActivityType}
                   </div>
+                  {activity.Account && activity.AccountID && (
+                    <div>
+                      Account:{' '}
+                      <Link to={`/accounts/${activity.AccountID}`} className="text-primary-600 hover:underline">
+                        {activity.Account.Name}
+                      </Link>
+                    </div>
+                  )}
+                  {activity.Lead && activity.LeadID && (
+                    <div>
+                      Lead:{' '}
+                      <Link to={`/leads/${activity.LeadID}`} className="text-primary-600 hover:underline">
+                        {activity.Lead.Name}
+                      </Link>
+                    </div>
+                  )}
                   {activity.Contact && (
                     <div>Contact: {activity.Contact.FirstName} {activity.Contact.LastName}</div>
                   )}

--- a/frontend/src/pages/Activities/ActivitiesList.tsx
+++ b/frontend/src/pages/Activities/ActivitiesList.tsx
@@ -8,7 +8,7 @@ export default function ActivitiesList() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['activities'],
     queryFn: async () => {
-      const response = await api.get('/Activities?$expand=Account,Contact,Employee&$orderby=ActivityTime desc')
+      const response = await api.get('/Activities?$expand=Account,Contact,Employee,Lead&$orderby=ActivityTime desc')
       return response.data
     },
   })

--- a/frontend/src/pages/Activities/ActivityDetail.tsx
+++ b/frontend/src/pages/Activities/ActivityDetail.tsx
@@ -14,7 +14,7 @@ export default function ActivityDetail() {
   const { data: activity, isLoading, error } = useQuery({
     queryKey: ['activity', id],
     queryFn: async () => {
-      const response = await api.get(`/Activities(${id})?$expand=Account,Contact,Employee`)
+      const response = await api.get(`/Activities(${id})?$expand=Account,Contact,Employee,Lead`)
       return response.data as Activity
     },
   })
@@ -71,11 +71,19 @@ export default function ActivityDetail() {
 
       <div className="card p-6 space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700 dark:text-gray-300">
-          {activity.Account && (
+          {activity.Account && activity.AccountID && (
             <div>
               <div className="font-medium text-gray-600 dark:text-gray-400">Account</div>
               <Link to={`/accounts/${activity.AccountID}`} className="text-primary-600 hover:underline">
                 {activity.Account.Name}
+              </Link>
+            </div>
+          )}
+          {activity.Lead && activity.LeadID && (
+            <div>
+              <div className="font-medium text-gray-600 dark:text-gray-400">Lead</div>
+              <Link to={`/leads/${activity.LeadID}`} className="text-primary-600 hover:underline">
+                {activity.Lead.Name}
               </Link>
             </div>
           )}

--- a/frontend/src/pages/Activities/ActivityForm.tsx
+++ b/frontend/src/pages/Activities/ActivityForm.tsx
@@ -28,17 +28,6 @@ export default function ActivityForm() {
     enabled: isEdit,
   })
 
-  const leadContextId = leadIdFromQuery || (activity?.LeadID ? activity.LeadID.toString() : undefined)
-
-  const { data: leadData } = useQuery({
-    queryKey: ['lead', leadContextId],
-    queryFn: async () => {
-      const response = await api.get(`/Leads(${leadContextId})`)
-      return response.data as Lead
-    },
-    enabled: Boolean(leadContextId),
-  })
-
   const { data: accountsData } = useQuery({
     queryKey: ['accounts'],
     queryFn: async () => {
@@ -51,6 +40,14 @@ export default function ActivityForm() {
     queryKey: ['employees'],
     queryFn: async () => {
       const response = await api.get('/Employees')
+      return response.data
+    },
+  })
+
+  const { data: leadsData } = useQuery({
+    queryKey: ['leads'],
+    queryFn: async () => {
+      const response = await api.get('/Leads?$orderby=Name asc')
       return response.data
     },
   })
@@ -89,8 +86,20 @@ export default function ActivityForm() {
   }
 
   const [formData, setFormData] = useState<Partial<Activity>>(getInitialFormData())
+  const [formError, setFormError] = useState<string | null>(null)
 
   const selectedAccountId = formData.AccountID
+  const selectedLeadId = formData.LeadID
+  const leadContextId = selectedLeadId ? selectedLeadId.toString() : undefined
+
+  const { data: leadData } = useQuery({
+    queryKey: ['lead', leadContextId],
+    queryFn: async () => {
+      const response = await api.get(`/Leads(${leadContextId})`)
+      return response.data as Lead
+    },
+    enabled: Boolean(leadContextId),
+  })
 
   const { data: contactsData } = useQuery({
     queryKey: ['contacts', selectedAccountId],
@@ -221,8 +230,8 @@ export default function ActivityForm() {
         queryClient.invalidateQueries({ queryKey: ['opportunity', variables.OpportunityID.toString()] })
       }
 
-      const leadNavigateId = !isEdit
-        ? (leadIdFromQuery || (variables.LeadID ? variables.LeadID.toString() : undefined))
+      const leadNavigateId = !isEdit && variables.LeadID
+        ? variables.LeadID.toString()
         : undefined
       if (leadNavigateId) {
         navigate(`/leads/${leadNavigateId}`)
@@ -245,6 +254,13 @@ export default function ActivityForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+
+    if (!formData.AccountID && !formData.LeadID) {
+      setFormError('Select an account or a lead to log the activity.')
+      return
+    }
+
+    setFormError(null)
     mutation.mutate(formData)
   }
 
@@ -259,15 +275,19 @@ export default function ActivityForm() {
       ...prev,
       [e.target.name]: value,
     }))
+    if (formError) {
+      setFormError(null)
+    }
   }
 
   const accounts = (accountsData?.items as Account[]) || []
   const contacts = selectedAccountId ? ((contactsData?.items as Contact[]) || []) : []
   const opportunities = selectedAccountId ? ((opportunitiesData?.items as Opportunity[]) || []) : []
   const employees = (employeesData?.items as Employee[]) || []
+  const leads = (leadsData?.items as Lead[]) || []
   const lead = leadData as Lead | undefined
-  const isLeadScoped = Boolean(leadIdFromQuery || formData.LeadID)
-  const leadLinkTarget = lead?.ID?.toString() || leadContextId || (formData.LeadID ? formData.LeadID.toString() : undefined)
+  const isLeadScoped = Boolean(selectedLeadId)
+  const leadLinkTarget = selectedLeadId ? selectedLeadId.toString() : undefined
   const leadDisplayName = lead?.Name || (leadLinkTarget ? `Lead #${leadLinkTarget}` : 'Lead')
 
   const activityTimeValue = formData.ActivityTime
@@ -330,6 +350,29 @@ export default function ActivityForm() {
                 Account selection is optional when logging lead activities.
               </p>
             )}
+          </div>
+
+          <div className="md:col-span-2">
+            <label htmlFor="LeadID" className="label">
+              Lead
+            </label>
+            <select
+              id="LeadID"
+              name="LeadID"
+              value={selectedLeadId ?? ''}
+              onChange={handleChange}
+              className="input"
+            >
+              <option value="">None</option>
+              {leads.map((leadOption: Lead) => (
+                <option key={leadOption.ID} value={leadOption.ID}>
+                  {leadOption.Name}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+              Selecting a lead makes the account optional for this activity.
+            </p>
           </div>
 
           <div>
@@ -473,6 +516,12 @@ export default function ActivityForm() {
             {mutation.isPending ? 'Saving...' : isEdit ? 'Update Activity' : 'Save Activity'}
           </Button>
         </div>
+
+        {formError && (
+          <div className="text-error-600 dark:text-error-400 text-sm">
+            {formError}
+          </div>
+        )}
 
         {mutation.isError && (
           <div className="text-error-600 dark:text-error-400 text-sm">

--- a/frontend/src/pages/Activities/ActivityForm.tsx
+++ b/frontend/src/pages/Activities/ActivityForm.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import api from '../../lib/api'
-import type { Activity, Account, Contact, Employee, Opportunity } from '../../types'
+import type { Activity, Account, Contact, Employee, Lead, Opportunity } from '../../types'
 import { Button, Input, Textarea } from '../../components/ui'
 
 const ACTIVITY_TYPES = ['Call', 'Email', 'Meeting', 'Note', 'Onsite Visit', 'Follow-up']
@@ -16,6 +16,7 @@ export default function ActivityForm() {
 
   const accountIdFromQuery = searchParams.get('accountId')
   const contactIdFromQuery = searchParams.get('contactId')
+  const leadIdFromQuery = searchParams.get('leadId')
   const opportunityIdFromQuery = searchParams.get('opportunityId')
 
   const { data: activity } = useQuery({
@@ -25,6 +26,17 @@ export default function ActivityForm() {
       return response.data as Activity
     },
     enabled: isEdit,
+  })
+
+  const leadContextId = leadIdFromQuery || (activity?.LeadID ? activity.LeadID.toString() : undefined)
+
+  const { data: leadData } = useQuery({
+    queryKey: ['lead', leadContextId],
+    queryFn: async () => {
+      const response = await api.get(`/Leads(${leadContextId})`)
+      return response.data as Lead
+    },
+    enabled: Boolean(leadContextId),
   })
 
   const { data: accountsData } = useQuery({
@@ -46,7 +58,8 @@ export default function ActivityForm() {
   const getInitialFormData = (): Partial<Activity> => {
     if (activity) {
       return {
-        AccountID: activity.AccountID,
+        AccountID: activity.AccountID ?? undefined,
+        LeadID: activity.LeadID ?? undefined,
         ContactID: activity.ContactID || undefined,
         EmployeeID: activity.EmployeeID || undefined,
         OpportunityID: activity.OpportunityID || undefined,
@@ -62,7 +75,8 @@ export default function ActivityForm() {
     const defaultTime = new Date(now.getTime() - now.getTimezoneOffset() * 60000).toISOString()
 
     return {
-      AccountID: accountIdFromQuery ? parseInt(accountIdFromQuery) : 0,
+      AccountID: accountIdFromQuery ? parseInt(accountIdFromQuery) : undefined,
+      LeadID: leadIdFromQuery ? parseInt(leadIdFromQuery) : undefined,
       ContactID: contactIdFromQuery ? parseInt(contactIdFromQuery) : undefined,
       EmployeeID: undefined,
       OpportunityID: opportunityIdFromQuery ? parseInt(opportunityIdFromQuery) : undefined,
@@ -162,6 +176,12 @@ export default function ActivityForm() {
   const mutation = useMutation({
     mutationFn: async (data: Partial<Activity>) => {
       const cleanData = { ...data }
+      if (!cleanData.AccountID) {
+        delete cleanData.AccountID
+      }
+      if (!cleanData.LeadID) {
+        delete cleanData.LeadID
+      }
       if (!cleanData.ContactID) {
         delete cleanData.ContactID
       }
@@ -192,8 +212,21 @@ export default function ActivityForm() {
         queryClient.invalidateQueries({ queryKey: ['account', variables.AccountID.toString()] })
       }
 
+      const leadIdForInvalidation = variables.LeadID ?? (leadIdFromQuery ? Number(leadIdFromQuery) : undefined)
+      if (leadIdForInvalidation) {
+        queryClient.invalidateQueries({ queryKey: ['lead', leadIdForInvalidation.toString()] })
+      }
+
       if (variables.OpportunityID) {
         queryClient.invalidateQueries({ queryKey: ['opportunity', variables.OpportunityID.toString()] })
+      }
+
+      const leadNavigateId = !isEdit
+        ? (leadIdFromQuery || (variables.LeadID ? variables.LeadID.toString() : undefined))
+        : undefined
+      if (leadNavigateId) {
+        navigate(`/leads/${leadNavigateId}`)
+        return
       }
 
       if (!isEdit && opportunityIdFromQuery) {
@@ -218,7 +251,7 @@ export default function ActivityForm() {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     let value: string | number | undefined = e.target.value
 
-    if (e.target.name === 'AccountID' || e.target.name === 'ContactID' || e.target.name === 'EmployeeID' || e.target.name === 'OpportunityID') {
+    if (e.target.name === 'AccountID' || e.target.name === 'ContactID' || e.target.name === 'EmployeeID' || e.target.name === 'LeadID' || e.target.name === 'OpportunityID') {
       value = value ? parseInt(value) : undefined
     }
 
@@ -228,10 +261,14 @@ export default function ActivityForm() {
     }))
   }
 
-  const accounts = accountsData?.items || []
+  const accounts = (accountsData?.items as Account[]) || []
   const contacts = selectedAccountId ? ((contactsData?.items as Contact[]) || []) : []
   const opportunities = selectedAccountId ? ((opportunitiesData?.items as Opportunity[]) || []) : []
   const employees = (employeesData?.items as Employee[]) || []
+  const lead = leadData as Lead | undefined
+  const isLeadScoped = Boolean(leadIdFromQuery || formData.LeadID)
+  const leadLinkTarget = lead?.ID?.toString() || leadContextId || (formData.LeadID ? formData.LeadID.toString() : undefined)
+  const leadDisplayName = lead?.Name || (leadLinkTarget ? `Lead #${leadLinkTarget}` : 'Lead')
 
   const activityTimeValue = formData.ActivityTime
     ? new Date(formData.ActivityTime).toISOString().slice(0, 16)
@@ -247,25 +284,52 @@ export default function ActivityForm() {
 
       <form onSubmit={handleSubmit} className="card p-6 space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {isLeadScoped && (
+            <div className="md:col-span-2">
+              <div className="rounded-lg border border-primary-200 dark:border-primary-800 bg-primary-50/60 dark:bg-primary-900/20 p-4">
+                <p className="text-sm text-primary-700 dark:text-primary-300">
+                  Linked to{' '}
+                  {leadLinkTarget ? (
+                    <Link to={`/leads/${leadLinkTarget}`} className="font-semibold hover:underline">
+                      {leadDisplayName}
+                    </Link>
+                  ) : (
+                    <span className="font-semibold">{leadDisplayName}</span>
+                  )}
+                </p>
+                {lead?.Company && (
+                  <p className="mt-1 text-xs text-primary-600 dark:text-primary-400">
+                    Company: {lead.Company}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
           <div className="md:col-span-2">
             <label htmlFor="AccountID" className="label">
-              Account *
+              Account{!isLeadScoped && ' *'}
             </label>
             <select
               id="AccountID"
               name="AccountID"
-              value={formData.AccountID}
+              value={formData.AccountID ?? ''}
               onChange={handleChange}
-              required
+              required={!isLeadScoped}
               className="input"
             >
-              <option value="">Select an account</option>
+              <option value="">{isLeadScoped ? 'None' : 'Select an account'}</option>
               {accounts.map((account: Account) => (
                 <option key={account.ID} value={account.ID}>
                   {account.Name}
                 </option>
               ))}
             </select>
+            {isLeadScoped && (
+              <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                Account selection is optional when logging lead activities.
+              </p>
+            )}
           </div>
 
           <div>

--- a/frontend/src/pages/Leads/LeadDetail.tsx
+++ b/frontend/src/pages/Leads/LeadDetail.tsx
@@ -3,9 +3,11 @@ import type { ChangeEvent } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { Button, Input } from '../../components/ui'
+import TaskList from '../../components/TaskList'
+import Timeline from '../../components/Timeline'
 import api from '../../lib/api'
 import { useConvertLead, useDeleteLead, useLead } from '../../lib/hooks/leads'
-import type { Account, Contact } from '../../types'
+import type { Account, Contact, Task, Activity } from '../../types'
 
 const escapeODataValue = (value: string) => value.replace(/'/g, "''")
 
@@ -41,6 +43,38 @@ export default function LeadDetail() {
   )
   const deleteMutation = useDeleteLead(id || '')
   const convertMutation = useConvertLead(id || '')
+
+  const {
+    data: leadTasksData,
+    isLoading: isLoadingLeadTasks,
+    error: leadTasksError,
+  } = useQuery({
+    queryKey: ['lead', id, 'tasks'],
+    queryFn: async () => {
+      const filter = encodeURIComponent(`LeadID eq ${id} and Status ne 3 and Status ne 5`)
+      const response = await api.get(
+        `/Tasks?$filter=${filter}&$orderby=DueDate asc&$top=5&$expand=Lead,Employee,Account,Contact`,
+      )
+      return response.data
+    },
+    enabled: Boolean(id),
+  })
+
+  const {
+    data: leadActivitiesData,
+    isLoading: isLoadingLeadActivities,
+    error: leadActivitiesError,
+  } = useQuery({
+    queryKey: ['lead', id, 'activities'],
+    queryFn: async () => {
+      const filter = encodeURIComponent(`LeadID eq ${id}`)
+      const response = await api.get(
+        `/Activities?$filter=${filter}&$orderby=ActivityTime desc&$top=5&$expand=Lead,Employee,Account,Contact`,
+      )
+      return response.data
+    },
+    enabled: Boolean(id),
+  })
 
   const leadIsConverted = lead?.Status === 'Converted' || Boolean(lead?.ConvertedAccountID)
 
@@ -189,6 +223,7 @@ export default function LeadDetail() {
     setShowConvertOptions(false)
   }
 
+
   if (!id) {
     return (
       <div className="text-center py-12 text-error-600 dark:text-error-400">
@@ -210,6 +245,13 @@ export default function LeadDetail() {
   }
 
   const isConverted = leadIsConverted
+  const openTasks = (leadTasksData?.items as Task[]) || []
+  const recentActivities = (leadActivitiesData?.items as Activity[]) || []
+  const tasksErrorMessage = leadTasksError as Error | null
+  const activitiesErrorMessage = leadActivitiesError as Error | null
+  const quickTaskTitle = `Follow up with ${lead.Name}`
+  const quickTaskUrl = `/tasks/new?leadId=${id}&title=${encodeURIComponent(quickTaskTitle)}`
+  const quickActivityUrl = `/activities/new?leadId=${id}`
 
   const handleDelete = () => {
     deleteMutation.mutate(undefined, {
@@ -572,6 +614,60 @@ export default function LeadDetail() {
               </div>
             )}
           </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="card p-6 space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Open Tasks</h2>
+            <Link to={quickTaskUrl} className="btn btn-primary text-sm">
+              New Task
+            </Link>
+          </div>
+          {isLoadingLeadTasks ? (
+            <p className="text-sm text-gray-600 dark:text-gray-400">Loading tasks...</p>
+          ) : tasksErrorMessage ? (
+            <p className="text-sm text-error-600 dark:text-error-400">
+              Unable to load tasks: {tasksErrorMessage.message}
+            </p>
+          ) : (
+            <TaskList
+              tasks={openTasks}
+              emptyMessage="No open tasks for this lead"
+              renderTitle={(task: Task) => (
+                <Link to={`/tasks/${task.ID}`} className="text-primary-600 hover:underline">
+                  {task.Title}
+                </Link>
+              )}
+            />
+          )}
+        </div>
+
+        <div className="card p-6 space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Recent Activities</h2>
+            <Link to={quickActivityUrl} className="btn btn-secondary text-sm">
+              Log Activity
+            </Link>
+          </div>
+          {isLoadingLeadActivities ? (
+            <p className="text-sm text-gray-600 dark:text-gray-400">Loading activities...</p>
+          ) : activitiesErrorMessage ? (
+            <p className="text-sm text-error-600 dark:text-error-400">
+              Unable to load activities: {activitiesErrorMessage.message}
+            </p>
+          ) : (
+            <Timeline
+              activities={recentActivities}
+              emptyMessage="No recent activity for this lead"
+              renderSubject={(activity: Activity) => (
+                <Link to={`/activities/${activity.ID}`} className="text-primary-600 hover:underline">
+                  {activity.Subject}
+                </Link>
+              )}
+            />
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/Tasks/TaskDetail.tsx
+++ b/frontend/src/pages/Tasks/TaskDetail.tsx
@@ -15,7 +15,7 @@ export default function TaskDetail() {
   const { data: task, isLoading, error } = useQuery({
     queryKey: ['task', id],
     queryFn: async () => {
-      const response = await api.get(`/Tasks(${id})?$expand=Account,Contact,Employee`)
+      const response = await api.get(`/Tasks(${id})?$expand=Account,Contact,Employee,Lead`)
       return response.data as Task
     },
   })
@@ -90,11 +90,19 @@ export default function TaskDetail() {
 
       <div className="card p-6 space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700 dark:text-gray-300">
-          {task.Account && (
+          {task.Account && task.AccountID && (
             <div>
               <div className="font-medium text-gray-600 dark:text-gray-400">Account</div>
               <Link to={`/accounts/${task.AccountID}`} className="text-primary-600 hover:underline">
                 {task.Account.Name}
+              </Link>
+            </div>
+          )}
+          {task.Lead && task.LeadID && (
+            <div>
+              <div className="font-medium text-gray-600 dark:text-gray-400">Lead</div>
+              <Link to={`/leads/${task.LeadID}`} className="text-primary-600 hover:underline">
+                {task.Lead.Name}
               </Link>
             </div>
           )}

--- a/frontend/src/pages/Tasks/TasksList.tsx
+++ b/frontend/src/pages/Tasks/TasksList.tsx
@@ -8,7 +8,7 @@ export default function TasksList() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['tasks'],
     queryFn: async () => {
-      const response = await api.get('/Tasks?$expand=Account,Contact,Employee&$orderby=DueDate asc')
+      const response = await api.get('/Tasks?$expand=Account,Contact,Employee,Lead&$orderby=DueDate asc')
       return response.data
     },
   })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -71,6 +71,8 @@ export interface Lead {
   ConvertedAccount?: Account
   ConvertedContact?: Contact
   OwnerEmployee?: Employee
+  Activities?: Activity[]
+  Tasks?: Task[]
 }
 
 export interface Issue {
@@ -96,7 +98,8 @@ export interface Issue {
 
 export interface Activity {
   ID: number
-  AccountID: number
+  AccountID?: number
+  LeadID?: number
   ContactID?: number
   EmployeeID?: number
   OpportunityID?: number
@@ -108,6 +111,7 @@ export interface Activity {
   CreatedAt: string
   UpdatedAt: string
   Account?: Account
+  Lead?: Lead
   Contact?: Contact
   Employee?: Employee
   Opportunity?: Opportunity
@@ -115,7 +119,8 @@ export interface Activity {
 
 export interface Task {
   ID: number
-  AccountID: number
+  AccountID?: number
+  LeadID?: number
   ContactID?: number
   EmployeeID?: number
   OpportunityID?: number
@@ -128,6 +133,7 @@ export interface Task {
   CreatedAt: string
   UpdatedAt: string
   Account?: Account
+  Lead?: Lead
   Contact?: Contact
   Employee?: Employee
   Opportunity?: Opportunity


### PR DESCRIPTION
## Summary
- allow activities and tasks to be associated with leads alongside accounts and seed example lead work
- surface lead-aware controls and navigation in the activity/task forms, detail pages, and shared UI components
- extend the lead detail view with open task and recent activity panels and quick create shortcuts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905ca2e4058832887d056d2d985da8f