### PR TITLE
Add opportunities pipeline board with drag-and-drop support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import TasksList from './pages/Tasks/TasksList'
 import TaskDetail from './pages/Tasks/TaskDetail'
 import TaskForm from './pages/Tasks/TaskForm'
 import OpportunitiesList from './pages/Opportunities/OpportunitiesList'
+import OpportunitiesBoard from './pages/Opportunities/OpportunitiesBoard'
 import OpportunityDetail from './pages/Opportunities/OpportunityDetail'
 import OpportunityForm from './pages/Opportunities/OpportunityForm'
 import EmployeesList from './pages/Employees/EmployeesList'
@@ -91,6 +92,7 @@ function App() {
 
             {/* Opportunities routes */}
             <Route path="opportunities" element={<OpportunitiesList />} />
+            <Route path="opportunities/board" element={<OpportunitiesBoard />} />
             <Route path="opportunities/new" element={<OpportunityForm />} />
             <Route path="opportunities/:id" element={<OpportunityDetail />} />
             <Route path="opportunities/:id/edit" element={<OpportunityForm />} />

--- a/frontend/src/components/DragDropBoard.tsx
+++ b/frontend/src/components/DragDropBoard.tsx
@@ -1,0 +1,143 @@
+import { useState, type DragEvent, type ReactNode } from 'react'
+
+export interface DragDropBoardColumn<TItem> {
+  id: string
+  title: string
+  items: TItem[]
+  summary?: ReactNode
+}
+
+interface DragState<TItem> {
+  columnId: string
+  item: TItem
+}
+
+export interface DragDropBoardProps<TItem> {
+  columns: Array<DragDropBoardColumn<TItem>>
+  /**
+   * Renders the card content for a given item.
+   */
+  renderItem: (item: TItem) => ReactNode
+  /**
+   * Callback executed when an item is dropped in a different column.
+   */
+  onItemDrop: (item: TItem, fromColumnId: string, toColumnId: string) => void
+  /**
+   * Returns a stable identifier for an item for React key usage.
+   */
+  getItemId: (item: TItem) => string | number
+  /**
+   * Message displayed when every column is empty.
+   */
+  emptyMessage?: ReactNode
+}
+
+function DragDropBoard<TItem>({
+  columns,
+  renderItem,
+  onItemDrop,
+  getItemId,
+  emptyMessage,
+}: DragDropBoardProps<TItem>) {
+  const [dragState, setDragState] = useState<DragState<TItem> | null>(null)
+  const [activeColumn, setActiveColumn] = useState<string | null>(null)
+
+  const handleDragStart = (columnId: string, item: TItem) => (event: DragEvent<HTMLDivElement>) => {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', String(getItemId(item)))
+    setDragState({ columnId, item })
+  }
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+  }
+
+  const handleDragEnter = (columnId: string) => (event: DragEvent<HTMLDivElement>) => {
+    if (!dragState) return
+    event.preventDefault()
+    setActiveColumn(columnId)
+  }
+
+  const handleDragLeave = (columnId: string) => () => {
+    if (activeColumn === columnId) {
+      setActiveColumn(null)
+    }
+  }
+
+  const handleDrop = (columnId: string) => (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (dragState && dragState.columnId !== columnId) {
+      onItemDrop(dragState.item, dragState.columnId, columnId)
+    }
+    setDragState(null)
+    setActiveColumn(null)
+  }
+
+  const handleDragEnd = () => {
+    setDragState(null)
+    setActiveColumn(null)
+  }
+
+  const allColumnsEmpty = columns.every((column) => column.items.length === 0)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {columns.map((column) => {
+          const isActive = activeColumn === column.id
+          return (
+            <div
+              key={column.id}
+              className={`flex-none w-80 bg-white dark:bg-gray-900 border ${
+                isActive
+                  ? 'border-primary-400 dark:border-primary-500 shadow-lg'
+                  : 'border-gray-200 dark:border-gray-800 shadow-sm'
+              } rounded-xl p-4 transition-all`}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop(column.id)}
+              onDragEnter={handleDragEnter(column.id)}
+              onDragLeave={handleDragLeave(column.id)}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{column.title}</h3>
+                <span className="text-sm text-gray-500 dark:text-gray-400">{column.items.length}</span>
+              </div>
+              {column.summary && (
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">{column.summary}</div>
+              )}
+
+              <div className="mt-4 space-y-3">
+                {column.items.map((item) => (
+                  <div
+                    key={getItemId(item)}
+                    draggable
+                    onDragStart={handleDragStart(column.id, item)}
+                    onDragEnd={handleDragEnd}
+                    className="cursor-grab active:cursor-grabbing rounded-lg border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-950 p-4 shadow-sm hover:shadow-md transition-shadow"
+                    aria-grabbed={dragState?.item === item}
+                  >
+                    {renderItem(item)}
+                  </div>
+                ))}
+
+                {column.items.length === 0 && (
+                  <div className="rounded-lg border border-dashed border-gray-200 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-950/80 p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                    Drag deals here
+                  </div>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {allColumnsEmpty && emptyMessage && (
+        <div className="text-center text-gray-600 dark:text-gray-400">{emptyMessage}</div>
+      )}
+    </div>
+  )
+}
+
+export default DragDropBoard

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,21 +9,37 @@ export default function Layout() {
   const { user, logout } = useAuth()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
-  const navigation = [
+  type NavigationItem = {
+    name: string
+    href: string
+    exact?: boolean
+    excludePrefixes?: string[]
+  }
+
+  const navigation: NavigationItem[] = [
     { name: 'Accounts', href: '/accounts' },
     { name: 'Leads', href: '/leads' },
     { name: 'Contacts', href: '/contacts' },
     { name: 'Activities', href: '/activities' },
     { name: 'Issues', href: '/issues' },
     { name: 'Tasks', href: '/tasks' },
-    { name: 'Opportunities', href: '/opportunities' },
+    { name: 'Opportunities', href: '/opportunities', excludePrefixes: ['/opportunities/board'] },
+    { name: 'Pipeline Board', href: '/opportunities/board', exact: true },
     { name: 'Employees', href: '/employees' },
     { name: 'Products', href: '/products' },
     { name: 'Workflows', href: '/settings/workflows' },
   ]
 
-  const isActive = (path: string) => {
-    return location.pathname.startsWith(path)
+  const isActive = (path: string, options?: { exact?: boolean; excludePrefixes?: string[] }) => {
+    if (options?.exact) {
+      return location.pathname === path
+    }
+
+    if (options?.excludePrefixes?.some((prefix) => location.pathname.startsWith(prefix))) {
+      return false
+    }
+
+    return location.pathname === path || location.pathname.startsWith(`${path}/`)
   }
 
   const toggleMobileMenu = () => {
@@ -127,7 +143,7 @@ export default function Layout() {
                       to={item.href}
                       onClick={closeMobileMenu}
                       className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                        isActive(item.href)
+                        isActive(item.href, { exact: item.exact, excludePrefixes: item.excludePrefixes })
                           ? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-200'
                           : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
                       }`}

--- a/frontend/src/pages/Opportunities/OpportunitiesBoard.tsx
+++ b/frontend/src/pages/Opportunities/OpportunitiesBoard.tsx
@@ -1,0 +1,183 @@
+import { useMemo } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import DragDropBoard, { type DragDropBoardColumn } from '@/components/DragDropBoard'
+import { Button } from '@/components/ui'
+import api from '@/lib/api'
+import { OPPORTUNITY_STAGES, type Opportunity } from '@/types'
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+})
+
+interface UpdateStageVariables {
+  id: number
+  stage: number
+}
+
+export default function OpportunitiesBoard() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const stages = OPPORTUNITY_STAGES()
+
+  const {
+    data: opportunities = [],
+    isLoading,
+    error,
+  } = useQuery<Opportunity[]>({
+    queryKey: ['opportunities', 'board'],
+    queryFn: async () => {
+      const response = await api.get('/Opportunities?$expand=Account,Contact,Owner&$orderby=Stage asc,Probability desc')
+      return (response.data.items as Opportunity[]) || []
+    },
+  })
+
+  const mutation = useMutation<void, Error, UpdateStageVariables, { previous?: Opportunity[] }>({
+    mutationFn: async ({ id, stage }) => {
+      await api.patch(`/Opportunities(${id})`, { Stage: stage })
+    },
+    onMutate: async ({ id, stage }) => {
+      await queryClient.cancelQueries({ queryKey: ['opportunities', 'board'] })
+      const previous = queryClient.getQueryData<Opportunity[]>(['opportunities', 'board'])
+
+      queryClient.setQueryData<Opportunity[]>(['opportunities', 'board'], (old) => {
+        if (!old) return old
+        return old.map((opportunity) =>
+          opportunity.ID === id
+            ? {
+                ...opportunity,
+                Stage: stage,
+                UpdatedAt: new Date().toISOString(),
+              }
+            : opportunity
+        )
+      })
+
+      return { previous }
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['opportunities', 'board'], context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['opportunities', 'board'] })
+    },
+  })
+
+  const columns: Array<DragDropBoardColumn<Opportunity>> = useMemo(() => {
+    return stages.map((stage) => {
+      const stageItems = opportunities.filter((opportunity) => opportunity.Stage === stage.value)
+      const stageTotal = stageItems.reduce((total, opportunity) => total + (opportunity.Amount || 0), 0)
+      return {
+        id: stage.value.toString(),
+        title: stage.label,
+        items: stageItems,
+        summary:
+          stageItems.length > 0
+            ? `${currencyFormatter.format(stageTotal)} pipeline`
+            : 'No deals',
+      }
+    })
+  }, [opportunities, stages])
+
+  const handleItemDrop = (opportunity: Opportunity, _fromColumnId: string, toColumnId: string) => {
+    const nextStage = Number(toColumnId)
+    if (!Number.isFinite(nextStage) || opportunity.Stage === nextStage) {
+      return
+    }
+
+    mutation.mutate({ id: opportunity.ID, stage: nextStage })
+  }
+
+  const renderOpportunityCard = (opportunity: Opportunity) => {
+    return (
+      <div className="space-y-3">
+        <div>
+          <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{opportunity.Name}</div>
+          {opportunity.Account && (
+            <div className="text-sm text-gray-600 dark:text-gray-400">{opportunity.Account.Name}</div>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+          <span className="font-semibold text-gray-900 dark:text-gray-100">
+            {currencyFormatter.format(opportunity.Amount)}
+          </span>
+          <span>{opportunity.Probability}% probability</span>
+          {opportunity.ExpectedCloseDate && (
+            <span>
+              Close {new Date(opportunity.ExpectedCloseDate).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+          {opportunity.Owner ? (
+            <span>
+              Owner: {opportunity.Owner.FirstName} {opportunity.Owner.LastName}
+            </span>
+          ) : (
+            <span>No owner assigned</span>
+          )}
+          <Link
+            to={`/opportunities/${opportunity.ID}`}
+            className="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
+          >
+            View
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Opportunities Board</h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Drag and drop deals between stages to keep your pipeline up to date.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="secondary" onClick={() => navigate('/opportunities')}>
+            List View
+          </Button>
+          <Button onClick={() => navigate('/opportunities/new')}>Create Opportunity</Button>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="py-8 text-center text-gray-600 dark:text-gray-400">Loading opportunities...</div>
+      )}
+
+      {error && (
+        <div className="py-8 text-center text-error-600 dark:text-error-400">
+          Error loading opportunities: {(error as Error).message}
+        </div>
+      )}
+
+      {mutation.isError && (
+        <div className="rounded-lg border border-error-200 bg-error-50 p-4 text-sm text-error-700 dark:border-error-700 dark:bg-error-900/40 dark:text-error-300">
+          Failed to update opportunity stage. Please try again.
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <DragDropBoard
+          columns={columns}
+          renderItem={renderOpportunityCard}
+          onItemDrop={handleItemDrop}
+          getItemId={(opportunity) => opportunity.ID}
+          emptyMessage={
+            <div className="space-y-2">
+              <p>No opportunities in your pipeline yet.</p>
+              <p>Use the create button to add your first deal.</p>
+            </div>
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Opportunities/OpportunitiesList.tsx
+++ b/frontend/src/pages/Opportunities/OpportunitiesList.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import api from '../../lib/api'
 import { mergeODataQuery } from '../../lib/odataUtils'
 import { Opportunity, OPPORTUNITY_STAGES, opportunityStageToString } from '../../types'
 import EntitySearch, { PaginationControls } from '../../components/EntitySearch'
+import { Button } from '@/components/ui'
 
 const currencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -28,6 +29,7 @@ const getStageBadgeClass = (stage: number) => {
 }
 
 export default function OpportunitiesList() {
+  const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(10)
@@ -57,9 +59,14 @@ export default function OpportunitiesList() {
             Monitor your sales pipeline, forecast revenue, and track upcoming closes.
           </p>
         </div>
-        <Link to="/opportunities/new" className="btn btn-primary">
-          Create Opportunity
-        </Link>
+        <div className="flex items-center gap-3">
+          <Button variant="secondary" onClick={() => navigate('/opportunities/board')}>
+            Board View
+          </Button>
+          <Link to="/opportunities/new" className="btn btn-primary">
+            Create Opportunity
+          </Link>
+        </div>
       </div>
 
       <EntitySearch

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   server: {
     port: 3000,
     host: true,


### PR DESCRIPTION
## Summary
- add a generic `DragDropBoard` component to provide reusable column drag-and-drop behaviour
- create an opportunities pipeline board page that groups deals by stage and patches stage updates when cards move
- expose the new board via routing/navigation and configure the Vite alias so `@/` imports resolve cleanly

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905cf378ab083288557c84044090ffe