### PR TITLE
Add CSV bulk import/export flows for accounts, contacts, and leads

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -159,6 +159,10 @@ func main() {
 		log.Fatal("Failed to register WorkflowExecution entity:", err)
 	}
 
+	if err := registerBulkDataActions(service, db); err != nil {
+		log.Fatal("Failed to register bulk data actions:", err)
+	}
+
 	if err := registerLeadConversionAction(service, db); err != nil {
 		log.Fatal("Failed to register lead conversion action:", err)
 	}
@@ -257,6 +261,215 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func registerBulkDataActions(service *odata.Service, db *gorm.DB) error {
+	if err := service.RegisterAction(odata.ActionDefinition{
+		Name:      "ImportAccountsCSV",
+		IsBound:   false,
+		EntitySet: "",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "Csv", Type: reflect.TypeOf(""), Required: true},
+		},
+		ReturnType: reflect.TypeOf(map[string]interface{}{}),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			csvPayload, ok := params["Csv"].(string)
+			if !ok || strings.TrimSpace(csvPayload) == "" {
+				return writeJSONError(w, http.StatusBadRequest, "Csv parameter is required")
+			}
+
+			accounts, validationErrors, err := database.ParseAccountsCSV(strings.NewReader(csvPayload))
+			if err != nil {
+				return writeJSONError(w, http.StatusBadRequest, err.Error())
+			}
+			if len(validationErrors) > 0 {
+				return writeValidationErrors(w, "One or more account rows could not be imported", validationErrors)
+			}
+			if len(accounts) == 0 {
+				return writeJSONError(w, http.StatusBadRequest, "No account rows were found in the CSV file")
+			}
+
+			if err := db.Create(&accounts).Error; err != nil {
+				return err
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			return json.NewEncoder(w).Encode(map[string]interface{}{
+				"imported": len(accounts),
+			})
+		},
+	}); err != nil {
+		return err
+	}
+
+	if err := service.RegisterAction(odata.ActionDefinition{
+		Name:       "ExportAccountsCSV",
+		IsBound:    false,
+		EntitySet:  "",
+		Parameters: nil,
+		ReturnType: nil,
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			var accounts []models.Account
+			if err := db.Order("id ASC").Find(&accounts).Error; err != nil {
+				return err
+			}
+
+			csvData, err := database.AccountsToCSV(accounts)
+			if err != nil {
+				return err
+			}
+
+			return writeCSVResponse(w, "accounts", csvData)
+		},
+	}); err != nil {
+		return err
+	}
+
+	if err := service.RegisterAction(odata.ActionDefinition{
+		Name:      "ImportContactsCSV",
+		IsBound:   false,
+		EntitySet: "",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "Csv", Type: reflect.TypeOf(""), Required: true},
+		},
+		ReturnType: reflect.TypeOf(map[string]interface{}{}),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			csvPayload, ok := params["Csv"].(string)
+			if !ok || strings.TrimSpace(csvPayload) == "" {
+				return writeJSONError(w, http.StatusBadRequest, "Csv parameter is required")
+			}
+
+			contacts, validationErrors, err := database.ParseContactsCSV(strings.NewReader(csvPayload))
+			if err != nil {
+				return writeJSONError(w, http.StatusBadRequest, err.Error())
+			}
+			if len(validationErrors) > 0 {
+				return writeValidationErrors(w, "One or more contact rows could not be imported", validationErrors)
+			}
+			if len(contacts) == 0 {
+				return writeJSONError(w, http.StatusBadRequest, "No contact rows were found in the CSV file")
+			}
+
+			if err := db.Create(&contacts).Error; err != nil {
+				return err
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			return json.NewEncoder(w).Encode(map[string]interface{}{
+				"imported": len(contacts),
+			})
+		},
+	}); err != nil {
+		return err
+	}
+
+	if err := service.RegisterAction(odata.ActionDefinition{
+		Name:       "ExportContactsCSV",
+		IsBound:    false,
+		EntitySet:  "",
+		Parameters: nil,
+		ReturnType: nil,
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			var contacts []models.Contact
+			if err := db.Order("id ASC").Find(&contacts).Error; err != nil {
+				return err
+			}
+
+			csvData, err := database.ContactsToCSV(contacts)
+			if err != nil {
+				return err
+			}
+
+			return writeCSVResponse(w, "contacts", csvData)
+		},
+	}); err != nil {
+		return err
+	}
+
+	if err := service.RegisterAction(odata.ActionDefinition{
+		Name:      "ImportLeadsCSV",
+		IsBound:   false,
+		EntitySet: "",
+		Parameters: []odata.ParameterDefinition{
+			{Name: "Csv", Type: reflect.TypeOf(""), Required: true},
+		},
+		ReturnType: reflect.TypeOf(map[string]interface{}{}),
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			csvPayload, ok := params["Csv"].(string)
+			if !ok || strings.TrimSpace(csvPayload) == "" {
+				return writeJSONError(w, http.StatusBadRequest, "Csv parameter is required")
+			}
+
+			leads, validationErrors, err := database.ParseLeadsCSV(strings.NewReader(csvPayload))
+			if err != nil {
+				return writeJSONError(w, http.StatusBadRequest, err.Error())
+			}
+			if len(validationErrors) > 0 {
+				return writeValidationErrors(w, "One or more lead rows could not be imported", validationErrors)
+			}
+			if len(leads) == 0 {
+				return writeJSONError(w, http.StatusBadRequest, "No lead rows were found in the CSV file")
+			}
+
+			if err := db.Create(&leads).Error; err != nil {
+				return err
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			return json.NewEncoder(w).Encode(map[string]interface{}{
+				"imported": len(leads),
+			})
+		},
+	}); err != nil {
+		return err
+	}
+
+	if err := service.RegisterAction(odata.ActionDefinition{
+		Name:       "ExportLeadsCSV",
+		IsBound:    false,
+		EntitySet:  "",
+		Parameters: nil,
+		ReturnType: nil,
+		Handler: func(w http.ResponseWriter, r *http.Request, ctx interface{}, params map[string]interface{}) error {
+			var leads []models.Lead
+			if err := db.Order("id ASC").Find(&leads).Error; err != nil {
+				return err
+			}
+
+			csvData, err := database.LeadsToCSV(leads)
+			if err != nil {
+				return err
+			}
+
+			return writeCSVResponse(w, "leads", csvData)
+		},
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeValidationErrors(w http.ResponseWriter, message string, details []database.RowError) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	return json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":   "validation_failed",
+		"message": message,
+		"details": details,
+	})
+}
+
+func writeCSVResponse(w http.ResponseWriter, prefix string, data []byte) error {
+	filename := fmt.Sprintf("%s-%s.csv", prefix, time.Now().UTC().Format("20060102-150405"))
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write(data)
+	return err
 }
 
 // registerLeadConversionAction exposes a bound OData action that converts a lead into an account and contact

--- a/backend/database/bulk.go
+++ b/backend/database/bulk.go
@@ -1,0 +1,450 @@
+package database
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/nlstn/my-crm/backend/models"
+)
+
+// RowError represents a validation error that occurred while parsing a CSV row.
+type RowError struct {
+	Row     int    `json:"row"`
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (e RowError) Error() string {
+	return fmt.Sprintf("row %d (%s): %s", e.Row, e.Field, e.Message)
+}
+
+var (
+	accountHeaders = []string{
+		"Name",
+		"Industry",
+		"Website",
+		"Phone",
+		"Email",
+		"Address",
+		"City",
+		"State",
+		"Country",
+		"PostalCode",
+		"Description",
+		"EmployeeID",
+	}
+
+	contactHeaders = []string{
+		"AccountID",
+		"FirstName",
+		"LastName",
+		"Title",
+		"Email",
+		"Phone",
+		"Mobile",
+		"IsPrimary",
+		"Notes",
+	}
+
+	leadHeaders = []string{
+		"Name",
+		"Email",
+		"Phone",
+		"Company",
+		"Title",
+		"Website",
+		"Source",
+		"Status",
+		"Notes",
+		"OwnerEmployeeID",
+	}
+)
+
+func readCSV(reader io.Reader) ([]string, [][]string, error) {
+	csvReader := csv.NewReader(reader)
+	csvReader.TrimLeadingSpace = true
+
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse CSV: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, nil, fmt.Errorf("CSV file is empty")
+	}
+
+	headers := make([]string, len(records[0]))
+	copy(headers, records[0])
+
+	return headers, records[1:], nil
+}
+
+func indexHeaders(headers []string) map[string]int {
+	index := make(map[string]int, len(headers))
+	for i, header := range headers {
+		normalized := strings.TrimSpace(header)
+		if normalized != "" {
+			index[normalized] = i
+		}
+	}
+	return index
+}
+
+func valueFor(row []string, headerIndex map[string]int, key string) string {
+	idx, ok := headerIndex[key]
+	if !ok || idx >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[idx])
+}
+
+func parseOptionalUint(value string) (*uint, *RowError) {
+	if value == "" {
+		return nil, nil
+	}
+
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return nil, &RowError{Field: "ID", Message: "must be a positive whole number"}
+	}
+	if parsed == 0 {
+		return nil, &RowError{Field: "ID", Message: "must be greater than zero"}
+	}
+	cast := uint(parsed)
+	return &cast, nil
+}
+
+func parseRequiredUint(value string, field string) (uint, *RowError) {
+	if value == "" {
+		return 0, &RowError{Field: field, Message: "is required"}
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, &RowError{Field: field, Message: "must be a positive whole number"}
+	}
+	if parsed == 0 {
+		return 0, &RowError{Field: field, Message: "must be greater than zero"}
+	}
+	return uint(parsed), nil
+}
+
+func parseBool(value string) (bool, *RowError) {
+	if value == "" {
+		return false, nil
+	}
+	lower := strings.ToLower(value)
+	switch lower {
+	case "true", "1", "yes", "y":
+		return true, nil
+	case "false", "0", "no", "n":
+		return false, nil
+	default:
+		return false, &RowError{Field: "IsPrimary", Message: "must be true or false"}
+	}
+}
+
+func ParseAccountsCSV(reader io.Reader) ([]models.Account, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	if _, ok := headerIndex["Name"]; !ok {
+		return nil, nil, fmt.Errorf("CSV is missing required header: Name")
+	}
+
+	var (
+		accounts  []models.Account
+		rowErrors []RowError
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2 // account for header row
+		name := valueFor(row, headerIndex, "Name")
+		if name == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Name", Message: "is required"})
+			continue
+		}
+
+		account := models.Account{
+			Name:        name,
+			Industry:    valueFor(row, headerIndex, "Industry"),
+			Website:     valueFor(row, headerIndex, "Website"),
+			Phone:       valueFor(row, headerIndex, "Phone"),
+			Email:       valueFor(row, headerIndex, "Email"),
+			Address:     valueFor(row, headerIndex, "Address"),
+			City:        valueFor(row, headerIndex, "City"),
+			State:       valueFor(row, headerIndex, "State"),
+			Country:     valueFor(row, headerIndex, "Country"),
+			PostalCode:  valueFor(row, headerIndex, "PostalCode"),
+			Description: valueFor(row, headerIndex, "Description"),
+		}
+
+		if employeeIDValue := valueFor(row, headerIndex, "EmployeeID"); employeeIDValue != "" {
+			employeeID, parseErr := parseOptionalUint(employeeIDValue)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "EmployeeID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			account.EmployeeID = employeeID
+		}
+
+		accounts = append(accounts, account)
+	}
+
+	return accounts, rowErrors, nil
+}
+
+func AccountsToCSV(accounts []models.Account) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(accountHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, account := range accounts {
+		record := []string{
+			account.Name,
+			account.Industry,
+			account.Website,
+			account.Phone,
+			account.Email,
+			account.Address,
+			account.City,
+			account.State,
+			account.Country,
+			account.PostalCode,
+			account.Description,
+			uintPointerToString(account.EmployeeID),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseContactsCSV(reader io.Reader) ([]models.Contact, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"AccountID", "FirstName", "LastName"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		contacts  []models.Contact
+		rowErrors []RowError
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		accountIDValue := valueFor(row, headerIndex, "AccountID")
+		accountID, parseErr := parseRequiredUint(accountIDValue, "AccountID")
+		if parseErr != nil {
+			parseErr.Row = currentRow
+			rowErrors = append(rowErrors, *parseErr)
+			continue
+		}
+
+		firstName := valueFor(row, headerIndex, "FirstName")
+		if firstName == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "FirstName", Message: "is required"})
+			continue
+		}
+
+		lastName := valueFor(row, headerIndex, "LastName")
+		if lastName == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "LastName", Message: "is required"})
+			continue
+		}
+
+		isPrimaryValue := valueFor(row, headerIndex, "IsPrimary")
+		isPrimary, boolErr := parseBool(isPrimaryValue)
+		if boolErr != nil {
+			boolErr.Row = currentRow
+			rowErrors = append(rowErrors, *boolErr)
+			continue
+		}
+
+		contact := models.Contact{
+			AccountID: accountID,
+			FirstName: firstName,
+			LastName:  lastName,
+			Title:     valueFor(row, headerIndex, "Title"),
+			Email:     valueFor(row, headerIndex, "Email"),
+			Phone:     valueFor(row, headerIndex, "Phone"),
+			Mobile:    valueFor(row, headerIndex, "Mobile"),
+			IsPrimary: isPrimary,
+			Notes:     valueFor(row, headerIndex, "Notes"),
+		}
+
+		contacts = append(contacts, contact)
+	}
+
+	return contacts, rowErrors, nil
+}
+
+func ContactsToCSV(contacts []models.Contact) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(contactHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, contact := range contacts {
+		record := []string{
+			strconv.FormatUint(uint64(contact.AccountID), 10),
+			contact.FirstName,
+			contact.LastName,
+			contact.Title,
+			contact.Email,
+			contact.Phone,
+			contact.Mobile,
+			strconv.FormatBool(contact.IsPrimary),
+			contact.Notes,
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseLeadsCSV(reader io.Reader) ([]models.Lead, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	if _, ok := headerIndex["Name"]; !ok {
+		return nil, nil, fmt.Errorf("CSV is missing required header: Name")
+	}
+
+	validStatuses := map[string]models.LeadStatus{
+		"New":          models.LeadStatusNew,
+		"Contacted":    models.LeadStatusContacted,
+		"Qualified":    models.LeadStatusQualified,
+		"Converted":    models.LeadStatusConverted,
+		"Disqualified": models.LeadStatusDisqualified,
+	}
+
+	var (
+		leads     []models.Lead
+		rowErrors []RowError
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		name := valueFor(row, headerIndex, "Name")
+		if name == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Name", Message: "is required"})
+			continue
+		}
+
+		lead := models.Lead{
+			Name:    name,
+			Email:   valueFor(row, headerIndex, "Email"),
+			Phone:   valueFor(row, headerIndex, "Phone"),
+			Company: valueFor(row, headerIndex, "Company"),
+			Title:   valueFor(row, headerIndex, "Title"),
+			Website: valueFor(row, headerIndex, "Website"),
+			Source:  valueFor(row, headerIndex, "Source"),
+			Notes:   valueFor(row, headerIndex, "Notes"),
+		}
+
+		if statusValue := valueFor(row, headerIndex, "Status"); statusValue != "" {
+			if status, ok := validStatuses[statusValue]; ok {
+				lead.Status = status
+			} else {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Status", Message: "must be one of New, Contacted, Qualified, Converted, Disqualified"})
+				continue
+			}
+		}
+
+		if ownerValue := valueFor(row, headerIndex, "OwnerEmployeeID"); ownerValue != "" {
+			ownerID, parseErr := parseOptionalUint(ownerValue)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "OwnerEmployeeID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			lead.OwnerEmployeeID = ownerID
+		}
+
+		leads = append(leads, lead)
+	}
+
+	return leads, rowErrors, nil
+}
+
+func LeadsToCSV(leads []models.Lead) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(leadHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, lead := range leads {
+		record := []string{
+			lead.Name,
+			lead.Email,
+			lead.Phone,
+			lead.Company,
+			lead.Title,
+			lead.Website,
+			lead.Source,
+			string(lead.Status),
+			lead.Notes,
+			uintPointerToString(lead.OwnerEmployeeID),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func uintPointerToString(value *uint) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatUint(uint64(*value), 10)
+}

--- a/frontend/src/pages/Accounts/AccountsList.tsx
+++ b/frontend/src/pages/Accounts/AccountsList.tsx
@@ -1,19 +1,36 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import type { ChangeEvent, FormEvent } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import api from '../../lib/api'
 import { mergeODataQuery } from '../../lib/odataUtils'
 import { Account } from '../../types'
 import { getLifecycleStageBadgeClass } from '../../constants/accounts'
 import EntitySearch, { PaginationControls } from '../../components/EntitySearch'
+import { Button, Input } from '@/components/ui'
+import type { AxiosError } from 'axios'
+
+interface BulkRowError {
+  row: number
+  field: string
+  message: string
+}
 
 export default function AccountsList() {
   const [searchQuery, setSearchQuery] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(10)
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [pageMessage, setPageMessage] = useState<string | null>(null)
+  const [pageError, setPageError] = useState<string | null>(null)
+  const [importErrors, setImportErrors] = useState<BulkRowError[]>([])
+  const [importErrorMessage, setImportErrorMessage] = useState<string | null>(null)
 
   // Merge search query with expand parameter
   const odataQuery = mergeODataQuery(searchQuery, { '$expand': 'Contacts,Issues,Tags' })
+
+  const queryClient = useQueryClient()
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['accounts', odataQuery],
@@ -25,16 +42,133 @@ export default function AccountsList() {
 
   const accounts = data?.items || []
 
+  const importMutation = useMutation({
+    mutationFn: async (csvText: string) => {
+      const response = await api.post('/ImportAccountsCSV', { Csv: csvText })
+      return response.data as { imported: number }
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      setPageMessage(`Imported ${result.imported} account${result.imported === 1 ? '' : 's'} successfully.`)
+      setPageError(null)
+      setImportErrors([])
+      setImportErrorMessage(null)
+      setSelectedFile(null)
+      setIsImportDialogOpen(false)
+    },
+    onError: (err: unknown) => {
+      let message = 'Failed to import accounts. Please check your CSV file and try again.'
+      const details: BulkRowError[] = []
+      if ((err as AxiosError)?.isAxiosError) {
+        const axiosError = err as AxiosError<{ message?: string; details?: BulkRowError[] }>
+        const data = axiosError.response?.data
+        if (data?.message) {
+          message = data.message
+        }
+        if (Array.isArray(data?.details)) {
+          for (const detail of data.details) {
+            if (detail && typeof detail.row === 'number' && typeof detail.field === 'string' && typeof detail.message === 'string') {
+              details.push(detail)
+            }
+          }
+        }
+      }
+      setImportErrorMessage(message)
+      setImportErrors(details)
+    },
+  })
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api.post('/ExportAccountsCSV', undefined, { responseType: 'blob' })
+      return response.data as Blob
+    },
+    onSuccess: (blob) => {
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `accounts-export-${new Date().toISOString().slice(0, 10)}.csv`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(url)
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      setPageMessage('Account export started. Your download should begin shortly.')
+      setPageError(null)
+    },
+    onError: () => {
+      setPageError('Failed to export accounts. Please try again.')
+    },
+  })
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null
+    setSelectedFile(file)
+  }
+
+  const handleImportSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedFile || importMutation.isPending) {
+      return
+    }
+    const csvText = await selectedFile.text()
+    setImportErrorMessage(null)
+    setImportErrors([])
+    importMutation.mutate(csvText)
+  }
+
+  const openImportDialog = () => {
+    setImportErrorMessage(null)
+    setImportErrors([])
+    setSelectedFile(null)
+    setIsImportDialogOpen(true)
+  }
+
+  const closeImportDialog = () => {
+    if (importMutation.isPending) {
+      return
+    }
+    setIsImportDialogOpen(false)
+    setSelectedFile(null)
+    setImportErrorMessage(null)
+    setImportErrors([])
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Accounts</h1>
         </div>
-        <Link to="/accounts/new" className="btn btn-primary">
-          Create Account
-        </Link>
+        <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => exportMutation.mutate()}
+            disabled={exportMutation.isPending}
+          >
+            {exportMutation.isPending ? 'Exporting…' : 'Export CSV'}
+          </Button>
+          <Button type="button" onClick={openImportDialog}>
+            Import CSV
+          </Button>
+          <Link to="/accounts/new" className="btn btn-primary text-center">
+            Create Account
+          </Link>
+        </div>
       </div>
+
+      {pageMessage && (
+        <div className="rounded-lg border border-success-200 bg-success-50 p-4 text-success-700 dark:border-success-800 dark:bg-success-950 dark:text-success-200">
+          {pageMessage}
+        </div>
+      )}
+
+      {pageError && (
+        <div className="rounded-lg border border-error-200 bg-error-50 p-4 text-error-700 dark:border-error-800 dark:bg-error-950 dark:text-error-200">
+          {pageError}
+        </div>
+      )}
 
       <EntitySearch
         searchPlaceholder="Search accounts..."
@@ -143,6 +277,56 @@ export default function AccountsList() {
             }}
           />
         </>
+      )}
+
+      {isImportDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-60 backdrop-blur-sm p-4">
+          <div className="card w-full max-w-lg p-6 space-y-4">
+            <div className="flex items-start justify-between">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Import Accounts from CSV</h2>
+              <Button type="button" variant="secondary" onClick={closeImportDialog} disabled={importMutation.isPending}>
+                Close
+              </Button>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Upload a CSV file that contains a header row with the expected Account columns.
+            </p>
+            {importErrorMessage && (
+              <div className="rounded-md border border-error-200 bg-error-50 p-4 text-sm text-error-700 dark:border-error-800 dark:bg-error-950 dark:text-error-200">
+                {importErrorMessage}
+              </div>
+            )}
+            {importErrors.length > 0 && (
+              <div className="rounded-md border border-warning-200 bg-warning-50 p-4 text-sm text-warning-700 dark:border-warning-800 dark:bg-warning-950 dark:text-warning-200">
+                <p className="font-semibold">Validation errors</p>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {importErrors.map((validationError) => (
+                    <li key={`${validationError.row}-${validationError.field}`}>
+                      Row {validationError.row}: {validationError.field} {validationError.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <form className="space-y-4" onSubmit={handleImportSubmit}>
+              <Input
+                type="file"
+                accept=".csv"
+                onChange={handleFileChange}
+                required
+                disabled={importMutation.isPending}
+              />
+              <div className="flex justify-end gap-3">
+                <Button type="button" variant="secondary" onClick={closeImportDialog} disabled={importMutation.isPending}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={!selectedFile || importMutation.isPending}>
+                  {importMutation.isPending ? 'Uploading…' : 'Start Import'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/Contacts/ContactsList.tsx
+++ b/frontend/src/pages/Contacts/ContactsList.tsx
@@ -1,18 +1,35 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import type { ChangeEvent, FormEvent } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import api from '../../lib/api'
 import { mergeODataQuery } from '../../lib/odataUtils'
 import { Contact } from '../../types'
 import EntitySearch, { PaginationControls } from '../../components/EntitySearch'
+import { Button, Input } from '@/components/ui'
+import type { AxiosError } from 'axios'
+
+interface BulkRowError {
+  row: number
+  field: string
+  message: string
+}
 
 export default function ContactsList() {
   const [searchQuery, setSearchQuery] = useState('')
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(10)
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [pageMessage, setPageMessage] = useState<string | null>(null)
+  const [pageError, setPageError] = useState<string | null>(null)
+  const [importErrors, setImportErrors] = useState<BulkRowError[]>([])
+  const [importErrorMessage, setImportErrorMessage] = useState<string | null>(null)
 
   // Merge search query with expand parameter
   const odataQuery = mergeODataQuery(searchQuery, { '$expand': 'Account' })
+
+  const queryClient = useQueryClient()
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['contacts', odataQuery],
@@ -24,16 +41,133 @@ export default function ContactsList() {
 
   const contacts = data?.items || []
 
+  const importMutation = useMutation({
+    mutationFn: async (csvText: string) => {
+      const response = await api.post('/ImportContactsCSV', { Csv: csvText })
+      return response.data as { imported: number }
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      setPageMessage(`Imported ${result.imported} contact${result.imported === 1 ? '' : 's'} successfully.`)
+      setPageError(null)
+      setImportErrors([])
+      setImportErrorMessage(null)
+      setSelectedFile(null)
+      setIsImportDialogOpen(false)
+    },
+    onError: (err: unknown) => {
+      let message = 'Failed to import contacts. Please review the CSV file and try again.'
+      const details: BulkRowError[] = []
+      if ((err as AxiosError)?.isAxiosError) {
+        const axiosError = err as AxiosError<{ message?: string; details?: BulkRowError[] }>
+        const data = axiosError.response?.data
+        if (data?.message) {
+          message = data.message
+        }
+        if (Array.isArray(data?.details)) {
+          for (const detail of data.details) {
+            if (detail && typeof detail.row === 'number' && typeof detail.field === 'string' && typeof detail.message === 'string') {
+              details.push(detail)
+            }
+          }
+        }
+      }
+      setImportErrorMessage(message)
+      setImportErrors(details)
+    },
+  })
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api.post('/ExportContactsCSV', undefined, { responseType: 'blob' })
+      return response.data as Blob
+    },
+    onSuccess: (blob) => {
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `contacts-export-${new Date().toISOString().slice(0, 10)}.csv`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(url)
+      queryClient.invalidateQueries({ queryKey: ['contacts'] })
+      setPageMessage('Contact export started. Your download should begin shortly.')
+      setPageError(null)
+    },
+    onError: () => {
+      setPageError('Failed to export contacts. Please try again.')
+    },
+  })
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null
+    setSelectedFile(file)
+  }
+
+  const handleImportSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedFile || importMutation.isPending) {
+      return
+    }
+    const csvText = await selectedFile.text()
+    setImportErrorMessage(null)
+    setImportErrors([])
+    importMutation.mutate(csvText)
+  }
+
+  const openImportDialog = () => {
+    setImportErrorMessage(null)
+    setImportErrors([])
+    setSelectedFile(null)
+    setIsImportDialogOpen(true)
+  }
+
+  const closeImportDialog = () => {
+    if (importMutation.isPending) {
+      return
+    }
+    setIsImportDialogOpen(false)
+    setSelectedFile(null)
+    setImportErrorMessage(null)
+    setImportErrors([])
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Contacts</h1>
         </div>
-        <Link to="/contacts/new" className="btn btn-primary">
-          Add Contact
-        </Link>
+        <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => exportMutation.mutate()}
+            disabled={exportMutation.isPending}
+          >
+            {exportMutation.isPending ? 'Exporting…' : 'Export CSV'}
+          </Button>
+          <Button type="button" onClick={openImportDialog}>
+            Import CSV
+          </Button>
+          <Link to="/contacts/new" className="btn btn-primary text-center">
+            Add Contact
+          </Link>
+        </div>
       </div>
+
+      {pageMessage && (
+        <div className="rounded-lg border border-success-200 bg-success-50 p-4 text-success-700 dark:border-success-800 dark:bg-success-950 dark:text-success-200">
+          {pageMessage}
+        </div>
+      )}
+
+      {pageError && (
+        <div className="rounded-lg border border-error-200 bg-error-50 p-4 text-error-700 dark:border-error-800 dark:bg-error-950 dark:text-error-200">
+          {pageError}
+        </div>
+      )}
 
       <EntitySearch
         searchPlaceholder="Search contacts..."
@@ -126,6 +260,56 @@ export default function ContactsList() {
             }}
           />
         </>
+      )}
+
+      {isImportDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-60 backdrop-blur-sm p-4">
+          <div className="card w-full max-w-lg p-6 space-y-4">
+            <div className="flex items-start justify-between">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Import Contacts from CSV</h2>
+              <Button type="button" variant="secondary" onClick={closeImportDialog} disabled={importMutation.isPending}>
+                Close
+              </Button>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Upload a CSV file containing contact details. Required headers include AccountID, FirstName, and LastName.
+            </p>
+            {importErrorMessage && (
+              <div className="rounded-md border border-error-200 bg-error-50 p-4 text-sm text-error-700 dark:border-error-800 dark:bg-error-950 dark:text-error-200">
+                {importErrorMessage}
+              </div>
+            )}
+            {importErrors.length > 0 && (
+              <div className="rounded-md border border-warning-200 bg-warning-50 p-4 text-sm text-warning-700 dark:border-warning-800 dark:bg-warning-950 dark:text-warning-200">
+                <p className="font-semibold">Validation errors</p>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {importErrors.map((validationError) => (
+                    <li key={`${validationError.row}-${validationError.field}`}>
+                      Row {validationError.row}: {validationError.field} {validationError.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <form className="space-y-4" onSubmit={handleImportSubmit}>
+              <Input
+                type="file"
+                accept=".csv"
+                onChange={handleFileChange}
+                required
+                disabled={importMutation.isPending}
+              />
+              <div className="flex justify-end gap-3">
+                <Button type="button" variant="secondary" onClick={closeImportDialog} disabled={importMutation.isPending}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={!selectedFile || importMutation.isPending}>
+                  {importMutation.isPending ? 'Uploading…' : 'Start Import'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- add reusable database helpers to validate and convert account, contact, and lead CSV data
- register go-odata actions for importing and exporting CSV data for key CRM entities
- expose React UI affordances for CSV uploads and downloads that keep entity lists in sync

## Testing
- not run (go build ./... hung while fetching modules; command aborted)


------
https://chatgpt.com/codex/tasks/task_e_6905cf4874148328b79eee5337a7011f