### PR TITLE
Support system theme preference in ThemeContext

### DIFF
--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,44 +1,90 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 
-type Theme = 'light' | 'dark'
+type ThemePreference = 'light' | 'dark' | 'system'
+type ResolvedTheme = 'light' | 'dark'
 
 interface ThemeContextType {
-  theme: Theme
-  toggleTheme: () => void
+  preference: ThemePreference
+  resolvedTheme: ResolvedTheme
+  setThemePreference: (preference: ThemePreference) => void
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    // Check localStorage first
-    const stored = localStorage.getItem('theme') as Theme | null
-    if (stored) return stored
-    
-    // Check system preference
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark'
+  const [preference, setPreference] = useState<ThemePreference>(() => {
+    if (typeof window === 'undefined') {
+      return 'system'
     }
-    
-    return 'light'
+
+    const stored = window.localStorage.getItem('theme') as ThemePreference | null
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored
+    }
+
+    return 'system'
+  })
+
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
+    if (typeof window === 'undefined') {
+      return 'light'
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   })
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    window.localStorage.setItem('theme', preference)
+  }, [preference])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+
+    const updateResolvedTheme = () => {
+      const nextResolved: ResolvedTheme =
+        preference === 'dark' || (preference === 'system' && media.matches) ? 'dark' : 'light'
+      setResolvedTheme(nextResolved)
+    }
+
+    updateResolvedTheme()
+
+    if (preference === 'system') {
+      media.addEventListener('change', updateResolvedTheme)
+      return () => {
+        media.removeEventListener('change', updateResolvedTheme)
+      }
+    }
+
+    return undefined
+  }, [preference])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return
+    }
+
     const root = document.documentElement
-    if (theme === 'dark') {
+    if (resolvedTheme === 'dark') {
       root.classList.add('dark')
     } else {
       root.classList.remove('dark')
     }
-    localStorage.setItem('theme', theme)
-  }, [theme])
+  }, [resolvedTheme])
 
-  const toggleTheme = () => {
-    setTheme(prev => prev === 'light' ? 'dark' : 'light')
+  const setThemePreference = (nextPreference: ThemePreference) => {
+    setPreference(nextPreference)
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ preference, resolvedTheme, setThemePreference }}>
       {children}
     </ThemeContext.Provider>
   )


### PR DESCRIPTION
## Summary
- add support for a `system` theme preference with resolved theme tracking in the context
- persist the chosen preference in localStorage and respond to system color scheme changes
- update the ThemeContext value and hook to expose preference, resolved theme, and a setter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905eb7727408328bd618c09b0617190