### PR TITLE
Add migration cockpit for bulk CSV import/export

### DIFF
--- a/frontend/public/templates/accounts-sample.csv
+++ b/frontend/public/templates/accounts-sample.csv
@@ -1,0 +1,3 @@
+Name,Industry,Phone,Website
+Acme Corporation,Manufacturing,555-0100,https://acme.example.com
+Globex Corp,Technology,555-0115,https://globex.example.com

--- a/frontend/public/templates/contacts-sample.csv
+++ b/frontend/public/templates/contacts-sample.csv
@@ -1,0 +1,3 @@
+AccountID,FirstName,LastName,Email,Phone,IsPrimary
+1,Amelia,Diaz,amelia.diaz@example.com,555-0160,true
+1,Jordan,Lee,jordan.lee@example.com,555-0188,false

--- a/frontend/public/templates/leads-sample.csv
+++ b/frontend/public/templates/leads-sample.csv
@@ -1,0 +1,3 @@
+FirstName,LastName,Company,Email,Status
+Kai,Williams,Northwind Traders,kai.williams@example.com,New
+Priya,Patel,Blue Ocean Systems,priya.patel@example.com,Contacted

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import ProductDetail from './pages/Products/ProductDetail'
 import ProductForm from './pages/Products/ProductForm'
 import WorkflowSettingsPage from './pages/Settings/Workflows'
 import UserPreferences from './pages/Settings/UserPreferences'
+import MigrationCockpit from './pages/Migration/MigrationCockpit'
 import { fetchEnums } from './lib/enums'
 
 function App() {
@@ -54,65 +55,68 @@ function App() {
             {/* Protected routes */}
             <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
               <Route index element={<Dashboard />} />
-            
-            {/* Accounts routes */}
-            <Route path="accounts" element={<AccountsList />} />
-            <Route path="accounts/new" element={<AccountForm />} />
-            <Route path="accounts/:id" element={<AccountDetail />} />
-            <Route path="accounts/:id/edit" element={<AccountForm />} />
 
-            {/* Leads routes */}
-            <Route path="leads" element={<LeadsList />} />
-            <Route path="leads/new" element={<LeadForm />} />
-            <Route path="leads/:id" element={<LeadDetail />} />
-            <Route path="leads/:id/edit" element={<LeadForm />} />
+              {/* Migration routes */}
+              <Route path="migration" element={<MigrationCockpit />} />
 
-            {/* Contacts routes */}
-            <Route path="contacts" element={<ContactsList />} />
-            <Route path="contacts/new" element={<ContactForm />} />
-            <Route path="contacts/:id" element={<ContactDetail />} />
-            <Route path="contacts/:id/edit" element={<ContactForm />} />
+              {/* Accounts routes */}
+              <Route path="accounts" element={<AccountsList />} />
+              <Route path="accounts/new" element={<AccountForm />} />
+              <Route path="accounts/:id" element={<AccountDetail />} />
+              <Route path="accounts/:id/edit" element={<AccountForm />} />
 
-            {/* Activities routes */}
-            <Route path="activities" element={<ActivitiesList />} />
-            <Route path="activities/new" element={<ActivityForm />} />
-            <Route path="activities/:id" element={<ActivityDetail />} />
-            <Route path="activities/:id/edit" element={<ActivityForm />} />
+              {/* Leads routes */}
+              <Route path="leads" element={<LeadsList />} />
+              <Route path="leads/new" element={<LeadForm />} />
+              <Route path="leads/:id" element={<LeadDetail />} />
+              <Route path="leads/:id/edit" element={<LeadForm />} />
 
-            {/* Issues routes */}
-            <Route path="issues" element={<IssuesList />} />
-            <Route path="issues/new" element={<IssueForm />} />
-            <Route path="issues/:id" element={<IssueDetail />} />
-            <Route path="issues/:id/edit" element={<IssueForm />} />
+              {/* Contacts routes */}
+              <Route path="contacts" element={<ContactsList />} />
+              <Route path="contacts/new" element={<ContactForm />} />
+              <Route path="contacts/:id" element={<ContactDetail />} />
+              <Route path="contacts/:id/edit" element={<ContactForm />} />
 
-            {/* Tasks routes */}
-            <Route path="tasks" element={<TasksList />} />
-            <Route path="tasks/new" element={<TaskForm />} />
-            <Route path="tasks/:id" element={<TaskDetail />} />
-            <Route path="tasks/:id/edit" element={<TaskForm />} />
+              {/* Activities routes */}
+              <Route path="activities" element={<ActivitiesList />} />
+              <Route path="activities/new" element={<ActivityForm />} />
+              <Route path="activities/:id" element={<ActivityDetail />} />
+              <Route path="activities/:id/edit" element={<ActivityForm />} />
 
-            {/* Opportunities routes */}
-            <Route path="opportunities" element={<OpportunitiesList />} />
-            <Route path="opportunities/board" element={<OpportunitiesBoard />} />
-            <Route path="opportunities/new" element={<OpportunityForm />} />
-            <Route path="opportunities/:id" element={<OpportunityDetail />} />
-            <Route path="opportunities/:id/edit" element={<OpportunityForm />} />
-            
-            {/* Employees routes */}
-            <Route path="employees" element={<EmployeesList />} />
-            <Route path="employees/new" element={<EmployeeForm />} />
-            <Route path="employees/:id" element={<EmployeeDetail />} />
-            <Route path="employees/:id/edit" element={<EmployeeForm />} />
-            
-            {/* Products routes */}
-            <Route path="products" element={<ProductsList />} />
-            <Route path="products/new" element={<ProductForm />} />
-            <Route path="products/:id" element={<ProductDetail />} />
-            <Route path="products/:id/edit" element={<ProductForm />} />
+              {/* Issues routes */}
+              <Route path="issues" element={<IssuesList />} />
+              <Route path="issues/new" element={<IssueForm />} />
+              <Route path="issues/:id" element={<IssueDetail />} />
+              <Route path="issues/:id/edit" element={<IssueForm />} />
 
-            {/* Settings routes */}
-            <Route path="settings/workflows" element={<WorkflowSettingsPage />} />
-            <Route path="settings/preferences" element={<UserPreferences />} />
+              {/* Tasks routes */}
+              <Route path="tasks" element={<TasksList />} />
+              <Route path="tasks/new" element={<TaskForm />} />
+              <Route path="tasks/:id" element={<TaskDetail />} />
+              <Route path="tasks/:id/edit" element={<TaskForm />} />
+
+              {/* Opportunities routes */}
+              <Route path="opportunities" element={<OpportunitiesList />} />
+              <Route path="opportunities/board" element={<OpportunitiesBoard />} />
+              <Route path="opportunities/new" element={<OpportunityForm />} />
+              <Route path="opportunities/:id" element={<OpportunityDetail />} />
+              <Route path="opportunities/:id/edit" element={<OpportunityForm />} />
+
+              {/* Employees routes */}
+              <Route path="employees" element={<EmployeesList />} />
+              <Route path="employees/new" element={<EmployeeForm />} />
+              <Route path="employees/:id" element={<EmployeeDetail />} />
+              <Route path="employees/:id/edit" element={<EmployeeForm />} />
+
+              {/* Products routes */}
+              <Route path="products" element={<ProductsList />} />
+              <Route path="products/new" element={<ProductForm />} />
+              <Route path="products/:id" element={<ProductDetail />} />
+              <Route path="products/:id/edit" element={<ProductForm />} />
+
+              {/* Settings routes */}
+              <Route path="settings/workflows" element={<WorkflowSettingsPage />} />
+              <Route path="settings/preferences" element={<UserPreferences />} />
             </Route>
           </Routes>
         </Router>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -94,6 +94,7 @@ export default function Layout() {
     { name: 'Pipeline Board', href: '/opportunities/board', exact: true },
     { name: 'Employees', href: '/employees' },
     { name: 'Products', href: '/products' },
+    { name: 'Migration Cockpit', href: '/migration', exact: true },
     { name: 'Workflows', href: '/settings/workflows' },
   ]
 

--- a/frontend/src/hooks/useCsvUpload.ts
+++ b/frontend/src/hooks/useCsvUpload.ts
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import type { ChangeEvent } from 'react'
+import { useMutation, useQueryClient, type QueryKey } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import api from '../lib/api'
+
+type StatusType = 'success' | 'error'
+
+export interface CsvStatus {
+  type: StatusType
+  message: string
+}
+
+export interface BulkRowError {
+  row: number
+  field: string
+  message: string
+}
+
+interface UseCsvUploadOptions {
+  importAction: string
+  entityLabel: string
+  queryKey?: QueryKey
+  formatSuccessMessage?: (importedCount: number) => string
+  formatErrorMessage?: () => string
+  onStatusChange?: (status: CsvStatus | null) => void
+}
+
+interface ImportResponse {
+  imported: number
+}
+
+export function useCsvUpload(options: UseCsvUploadOptions) {
+  const {
+    importAction,
+    entityLabel,
+    queryKey,
+    formatSuccessMessage,
+    formatErrorMessage,
+    onStatusChange,
+  } = options
+
+  const queryClient = useQueryClient()
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [rowErrors, setRowErrors] = useState<BulkRowError[]>([])
+
+  const importMutation = useMutation({
+    mutationFn: async (csvText: string) => {
+      const response = await api.post(importAction, { Csv: csvText })
+      return response.data as ImportResponse
+    },
+    onSuccess: (result) => {
+      if (queryKey) {
+        queryClient.invalidateQueries({ queryKey })
+      }
+
+      setRowErrors([])
+      setSelectedFile(null)
+
+      const message = formatSuccessMessage
+        ? formatSuccessMessage(result.imported)
+        : `Imported ${result.imported} ${entityLabel.toLowerCase()}${result.imported === 1 ? '' : 's'} successfully.`
+
+      onStatusChange?.({ type: 'success', message })
+    },
+    onError: (err: unknown) => {
+      let message = formatErrorMessage
+        ? formatErrorMessage()
+        : `Failed to import ${entityLabel.toLowerCase()} data. Please review the CSV file and try again.`
+
+      const details: BulkRowError[] = []
+      if ((err as AxiosError)?.isAxiosError) {
+        const axiosError = err as AxiosError<{ message?: string; details?: BulkRowError[] }>
+        const data = axiosError.response?.data
+
+        if (data?.message) {
+          message = data.message
+        }
+
+        if (Array.isArray(data?.details)) {
+          for (const detail of data.details) {
+            if (
+              detail &&
+              typeof detail.row === 'number' &&
+              typeof detail.field === 'string' &&
+              typeof detail.message === 'string'
+            ) {
+              details.push(detail)
+            }
+          }
+        }
+      }
+
+      setRowErrors(details)
+      onStatusChange?.({ type: 'error', message })
+    },
+  })
+
+  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null
+    setSelectedFile(file)
+    setRowErrors([])
+    onStatusChange?.(null)
+  }
+
+  const submit = async () => {
+    if (!selectedFile || importMutation.isPending) {
+      if (!selectedFile) {
+        onStatusChange?.({ type: 'error', message: 'Select a CSV file before importing.' })
+      }
+      return
+    }
+
+    try {
+      const csvText = await selectedFile.text()
+      setRowErrors([])
+      onStatusChange?.(null)
+      importMutation.mutate(csvText)
+    } catch {
+      onStatusChange?.({
+        type: 'error',
+        message: 'Unable to read the selected file. Please try again or choose a different CSV file.',
+      })
+    }
+  }
+
+  return {
+    selectedFile,
+    handleFileInputChange,
+    submit,
+    isUploading: importMutation.isPending,
+    rowErrors,
+  }
+}

--- a/frontend/src/pages/Accounts/AccountsList.tsx
+++ b/frontend/src/pages/Accounts/AccountsList.tsx
@@ -139,6 +139,16 @@ export default function AccountsList() {
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Accounts</h1>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            Manage bulk imports and exports from the{' '}
+            <Link
+              to="/migration"
+              className="font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+            >
+              Migration Cockpit
+            </Link>
+            .
+          </p>
         </div>
         <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
           <Button

--- a/frontend/src/pages/Contacts/ContactsList.tsx
+++ b/frontend/src/pages/Contacts/ContactsList.tsx
@@ -138,6 +138,16 @@ export default function ContactsList() {
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Contacts</h1>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            For a dedicated import and export workspace visit the{' '}
+            <Link
+              to="/migration"
+              className="font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+            >
+              Migration Cockpit
+            </Link>
+            .
+          </p>
         </div>
         <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
           <Button

--- a/frontend/src/pages/Leads/LeadsList.tsx
+++ b/frontend/src/pages/Leads/LeadsList.tsx
@@ -217,6 +217,16 @@ export default function LeadsList() {
           <p className="mt-2 text-gray-600 dark:text-gray-400">
             Capture and manage prospects before converting them into accounts.
           </p>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            Streamline bulk imports and exports in the{' '}
+            <Link
+              to="/migration"
+              className="font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+            >
+              Migration Cockpit
+            </Link>
+            .
+          </p>
         </div>
         <div className="flex flex-col sm:flex-row gap-3">
           <Button

--- a/frontend/src/pages/Migration/MigrationCockpit.tsx
+++ b/frontend/src/pages/Migration/MigrationCockpit.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { useMutation, type QueryKey } from '@tanstack/react-query'
+import { Button, Input } from '@/components/ui'
+import api from '../../lib/api'
+import { useCsvUpload, type CsvStatus } from '../../hooks/useCsvUpload'
+
+type MigrationEntity = {
+  key: string
+  label: string
+  description: string
+  successNoun: string
+  importAction: string
+  exportAction: string
+  sampleTemplateHref: string
+  queryKey?: QueryKey
+}
+
+type StatusMessage = CsvStatus | null
+
+const MIGRATION_ENTITIES: MigrationEntity[] = [
+  {
+    key: 'accounts',
+    label: 'Accounts',
+    description: 'Import or export customer account records in bulk, including company details and contact information.',
+    successNoun: 'account',
+    importAction: '/ImportAccountsCSV',
+    exportAction: '/ExportAccountsCSV',
+    sampleTemplateHref: '/templates/accounts-sample.csv',
+    queryKey: ['accounts'],
+  },
+  {
+    key: 'contacts',
+    label: 'Contacts',
+    description: 'Manage people associated with your accounts. Imports support primary contact flags and email addresses.',
+    successNoun: 'contact',
+    importAction: '/ImportContactsCSV',
+    exportAction: '/ExportContactsCSV',
+    sampleTemplateHref: '/templates/contacts-sample.csv',
+    queryKey: ['contacts'],
+  },
+  {
+    key: 'leads',
+    label: 'Leads',
+    description: 'Bring in prospect lists or export marketing outreach data, including lifecycle status updates.',
+    successNoun: 'lead',
+    importAction: '/ImportLeadsCSV',
+    exportAction: '/ExportLeadsCSV',
+    sampleTemplateHref: '/templates/leads-sample.csv',
+    queryKey: ['leads'],
+  },
+]
+
+function MigrationTile({ entity }: { entity: MigrationEntity }) {
+  const [status, setStatus] = useState<StatusMessage>(null)
+
+  const { selectedFile, handleFileInputChange, submit, isUploading, rowErrors } = useCsvUpload({
+    importAction: entity.importAction,
+    entityLabel: entity.label,
+    queryKey: entity.queryKey,
+    formatSuccessMessage: (count) =>
+      `Imported ${count} ${entity.successNoun}${count === 1 ? '' : 's'} successfully.`,
+    formatErrorMessage: () =>
+      `Failed to import ${entity.label.toLowerCase()} data. Please review the CSV file and try again.`,
+    onStatusChange: setStatus,
+  })
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api.post(entity.exportAction, undefined, { responseType: 'blob' })
+      return response.data as Blob
+    },
+    onSuccess: (blob) => {
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `${entity.key}-export-${new Date().toISOString().slice(0, 10)}.csv`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(url)
+      setStatus({
+        type: 'success',
+        message: `${entity.label} export started. Your download should begin shortly.`,
+      })
+    },
+    onError: () => {
+      setStatus({
+        type: 'error',
+        message: `Failed to export ${entity.label.toLowerCase()}. Please try again.`,
+      })
+    },
+  })
+
+  return (
+    <section className="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{entity.label}</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400">{entity.description}</p>
+      </div>
+
+      {status && (
+        <div
+          className={`rounded-md border p-4 text-sm ${
+            status.type === 'success'
+              ? 'border-success-200 bg-success-50 text-success-700 dark:border-success-800 dark:bg-success-950 dark:text-success-200'
+              : 'border-error-200 bg-error-50 text-error-700 dark:border-error-800 dark:bg-error-950 dark:text-error-200'
+          }`}
+        >
+          {status.message}
+        </div>
+      )}
+
+      {rowErrors.length > 0 && (
+        <div className="rounded-md border border-warning-200 bg-warning-50 p-4 text-sm text-warning-700 dark:border-warning-800 dark:bg-warning-950 dark:text-warning-200">
+          <p className="font-semibold">Validation errors</p>
+          <ul className="mt-2 space-y-1 pl-4">
+            {rowErrors.map((error) => (
+              <li key={`${error.row}-${error.field}`}>
+                Row {error.row}: {error.field} {error.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Input
+            type="file"
+            accept=".csv"
+            onChange={handleFileInputChange}
+            disabled={isUploading}
+          />
+          <Button onClick={submit} disabled={isUploading}>
+            {isUploading ? 'Uploading…' : 'Start Import'}
+          </Button>
+        </div>
+        {selectedFile && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">Selected file: {selectedFile.name}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => exportMutation.mutate()}
+          disabled={exportMutation.isPending}
+        >
+          {exportMutation.isPending ? 'Exporting…' : 'Export CSV'}
+        </Button>
+        <a
+          href={entity.sampleTemplateHref}
+          className="text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+          download
+        >
+          Download sample CSV
+        </a>
+      </div>
+    </section>
+  )
+}
+
+export default function MigrationCockpit() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Migration Cockpit</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Centralize imports and exports for core CRM entities. Use the sample templates to format your CSV files before
+          uploading.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {MIGRATION_ENTITIES.map((entity) => (
+          <MigrationTile key={entity.key} entity={entity} />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a Migration Cockpit page with tiles for account, contact, and lead CSV import/export actions powered by React Query mutations
- introduce a reusable CSV upload hook and sample templates to centralize file handling and validation messaging
- expose the cockpit through the authenticated router, navigation, and entity page helper text for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905fb9105a48328ba3bfe773d5c1fce