### PR TITLE
Add CSV bulk helpers and cockpit overview

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,6 +38,27 @@ All APIs are built using `go-odata` and strictly follow the OData v4 specificati
 - `PATCH /Accounts(1)` - Update account
 - `DELETE /Accounts(1)` - Delete account
 
+### Bulk Data Actions
+
+All bulk import/export operations are exposed as unbound OData actions that accept or return CSV payloads. Import actions return a
+JSON object containing the number of imported rows when successful and emit structured validation errors when foreign-key
+dependencies are missing. Export actions stream UTF-8 CSV attachments.
+
+| Entity                    | Import Action                     | Export Action                          |
+|---------------------------|-----------------------------------|----------------------------------------|
+| Accounts                  | `POST /ImportAccountsCSV`         | `POST /ExportAccountsCSV`              |
+| Contacts                  | `POST /ImportContactsCSV`         | `POST /ExportContactsCSV`              |
+| Leads                     | `POST /ImportLeadsCSV`            | `POST /ExportLeadsCSV`                 |
+| Activities                | `POST /ImportActivitiesCSV`       | `POST /ExportActivitiesCSV`            |
+| Issues                    | `POST /ImportIssuesCSV`           | `POST /ExportIssuesCSV`                |
+| Tasks                     | `POST /ImportTasksCSV`            | `POST /ExportTasksCSV`                 |
+| Opportunities             | `POST /ImportOpportunitiesCSV`    | `POST /ExportOpportunitiesCSV`         |
+| Opportunity Line Items    | `POST /ImportOpportunityLineItemsCSV` | `POST /ExportOpportunityLineItemsCSV` |
+| Employees                 | `POST /ImportEmployeesCSV`        | `POST /ExportEmployeesCSV`             |
+| Products                  | `POST /ImportProductsCSV`         | `POST /ExportProductsCSV`              |
+
+All timestamps should be provided in RFC3339 format, and numeric identifiers must reference existing records to pass validation.
+
 ### Contacts
 - `GET /Contacts` - List all contacts
 - `GET /Contacts(1)` - Get specific contact

--- a/backend/database/bulk.go
+++ b/backend/database/bulk.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nlstn/my-crm/backend/models"
 )
@@ -61,6 +62,126 @@ var (
 		"Status",
 		"Notes",
 		"OwnerEmployeeID",
+	}
+
+	activityHeaders = []string{
+		"AccountID",
+		"LeadID",
+		"ContactID",
+		"EmployeeID",
+		"OpportunityID",
+		"ActivityType",
+		"Subject",
+		"Outcome",
+		"Notes",
+		"ActivityTime",
+	}
+
+	issueHeaders = []string{
+		"AccountID",
+		"ContactID",
+		"Title",
+		"Description",
+		"Status",
+		"Priority",
+		"AssignedTo",
+		"Resolution",
+		"EmployeeID",
+		"DueDate",
+		"ResolvedAt",
+	}
+
+	taskHeaders = []string{
+		"AccountID",
+		"LeadID",
+		"ContactID",
+		"EmployeeID",
+		"OpportunityID",
+		"Title",
+		"Description",
+		"Owner",
+		"Status",
+		"DueDate",
+		"CompletedAt",
+	}
+
+	opportunityHeaders = []string{
+		"AccountID",
+		"ContactID",
+		"OwnerEmployeeID",
+		"Name",
+		"Amount",
+		"Probability",
+		"ExpectedCloseDate",
+		"Stage",
+		"Description",
+		"ClosedAt",
+		"CloseReason",
+		"ClosedByEmployeeID",
+	}
+
+	opportunityLineItemHeaders = []string{
+		"OpportunityID",
+		"ProductID",
+		"Quantity",
+		"UnitPrice",
+		"DiscountAmount",
+		"DiscountPercent",
+	}
+
+	employeeHeaders = []string{
+		"FirstName",
+		"LastName",
+		"Email",
+		"Phone",
+		"Department",
+		"Position",
+		"HireDate",
+		"Notes",
+	}
+
+	productHeaders = []string{
+		"Name",
+		"SKU",
+		"Category",
+		"Description",
+		"Price",
+		"Cost",
+		"Stock",
+		"IsActive",
+	}
+
+	issueStatusByName = map[string]models.IssueStatus{
+		"new":        models.IssueStatusNew,
+		"inprogress": models.IssueStatusInProgress,
+		"pending":    models.IssueStatusPending,
+		"resolved":   models.IssueStatusResolved,
+		"closed":     models.IssueStatusClosed,
+	}
+
+	issuePriorityByName = map[string]models.IssuePriority{
+		"low":      models.IssuePriorityLow,
+		"medium":   models.IssuePriorityMedium,
+		"high":     models.IssuePriorityHigh,
+		"critical": models.IssuePriorityCritical,
+	}
+
+	taskStatusByName = map[string]models.TaskStatus{
+		"notstarted": models.TaskStatusNotStarted,
+		"inprogress": models.TaskStatusInProgress,
+		"completed":  models.TaskStatusCompleted,
+		"deferred":   models.TaskStatusDeferred,
+		"cancelled":  models.TaskStatusCancelled,
+	}
+
+	opportunityStageByName = map[string]models.OpportunityStage{
+		"prospecting":   models.OpportunityStageProspecting,
+		"qualification": models.OpportunityStageQualification,
+		"needsanalysis": models.OpportunityStageNeedsAnalysis,
+		"proposal":      models.OpportunityStageProposal,
+		"negotiation":   models.OpportunityStageNegotiation,
+		"closedwon":     models.OpportunityStageClosedWon,
+		"closedlost":    models.OpportunityStageClosedLost,
 	}
 )
 
@@ -131,35 +252,105 @@ func parseRequiredUint(value string, field string) (uint, *RowError) {
 	return uint(parsed), nil
 }
 
-func parseBool(value string) (bool, *RowError) {
+func parseOptionalBool(value string, field string) (*bool, *RowError) {
 	if value == "" {
-		return false, nil
+		return nil, nil
 	}
 	lower := strings.ToLower(value)
 	switch lower {
 	case "true", "1", "yes", "y":
-		return true, nil
+		result := true
+		return &result, nil
 	case "false", "0", "no", "n":
-		return false, nil
+		result := false
+		return &result, nil
 	default:
-		return false, &RowError{Field: "IsPrimary", Message: "must be true or false"}
+		return nil, &RowError{Field: field, Message: "must be true or false"}
 	}
 }
 
-func ParseAccountsCSV(reader io.Reader) ([]models.Account, []RowError, error) {
+func parseRequiredFloat(value string, field string) (float64, *RowError) {
+	if value == "" {
+		return 0, &RowError{Field: field, Message: "is required"}
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, &RowError{Field: field, Message: "must be a valid number"}
+	}
+	return parsed, nil
+}
+
+func parseOptionalFloat(value string, field string) (float64, *RowError) {
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, &RowError{Field: field, Message: "must be a valid number"}
+	}
+	return parsed, nil
+}
+
+func parseRequiredInt(value string, field string) (int, *RowError) {
+	if value == "" {
+		return 0, &RowError{Field: field, Message: "is required"}
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, &RowError{Field: field, Message: "must be a whole number"}
+	}
+	return parsed, nil
+}
+
+func parseOptionalInt(value string, field string) (int, *RowError) {
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, &RowError{Field: field, Message: "must be a whole number"}
+	}
+	return parsed, nil
+}
+
+func parseRequiredTime(value string, field string) (time.Time, *RowError) {
+	if value == "" {
+		return time.Time{}, &RowError{Field: field, Message: "is required"}
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, &RowError{Field: field, Message: "must be in RFC3339 format"}
+	}
+	return parsed.UTC(), nil
+}
+
+func parseOptionalTime(value string, field string) (*time.Time, *RowError) {
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, &RowError{Field: field, Message: "must be in RFC3339 format"}
+	}
+	result := parsed.UTC()
+	return &result, nil
+}
+
+func ParseAccountsCSV(reader io.Reader) ([]models.Account, []int, []RowError, error) {
 	headers, rows, err := readCSV(reader)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	headerIndex := indexHeaders(headers)
 	if _, ok := headerIndex["Name"]; !ok {
-		return nil, nil, fmt.Errorf("CSV is missing required header: Name")
+		return nil, nil, nil, fmt.Errorf("CSV is missing required header: Name")
 	}
 
 	var (
-		accounts  []models.Account
-		rowErrors []RowError
+		accounts   []models.Account
+		rowErrors  []RowError
+		rowNumbers []int
 	)
 
 	for rowIndex, row := range rows {
@@ -196,9 +387,10 @@ func ParseAccountsCSV(reader io.Reader) ([]models.Account, []RowError, error) {
 		}
 
 		accounts = append(accounts, account)
+		rowNumbers = append(rowNumbers, currentRow)
 	}
 
-	return accounts, rowErrors, nil
+	return accounts, rowNumbers, rowErrors, nil
 }
 
 func AccountsToCSV(accounts []models.Account) ([]byte, error) {
@@ -237,23 +429,24 @@ func AccountsToCSV(accounts []models.Account) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func ParseContactsCSV(reader io.Reader) ([]models.Contact, []RowError, error) {
+func ParseContactsCSV(reader io.Reader) ([]models.Contact, []int, []RowError, error) {
 	headers, rows, err := readCSV(reader)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	headerIndex := indexHeaders(headers)
 	requiredHeaders := []string{"AccountID", "FirstName", "LastName"}
 	for _, header := range requiredHeaders {
 		if _, ok := headerIndex[header]; !ok {
-			return nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
 		}
 	}
 
 	var (
-		contacts  []models.Contact
-		rowErrors []RowError
+		contacts   []models.Contact
+		rowErrors  []RowError
+		rowNumbers []int
 	)
 
 	for rowIndex, row := range rows {
@@ -279,12 +472,17 @@ func ParseContactsCSV(reader io.Reader) ([]models.Contact, []RowError, error) {
 			continue
 		}
 
-		isPrimaryValue := valueFor(row, headerIndex, "IsPrimary")
-		isPrimary, boolErr := parseBool(isPrimaryValue)
-		if boolErr != nil {
-			boolErr.Row = currentRow
-			rowErrors = append(rowErrors, *boolErr)
-			continue
+		isPrimary := false
+		if isPrimaryValue := valueFor(row, headerIndex, "IsPrimary"); isPrimaryValue != "" {
+			parsed, boolErr := parseOptionalBool(isPrimaryValue, "IsPrimary")
+			if boolErr != nil {
+				boolErr.Row = currentRow
+				rowErrors = append(rowErrors, *boolErr)
+				continue
+			}
+			if parsed != nil {
+				isPrimary = *parsed
+			}
 		}
 
 		contact := models.Contact{
@@ -300,9 +498,10 @@ func ParseContactsCSV(reader io.Reader) ([]models.Contact, []RowError, error) {
 		}
 
 		contacts = append(contacts, contact)
+		rowNumbers = append(rowNumbers, currentRow)
 	}
 
-	return contacts, rowErrors, nil
+	return contacts, rowNumbers, rowErrors, nil
 }
 
 func ContactsToCSV(contacts []models.Contact) ([]byte, error) {
@@ -338,15 +537,15 @@ func ContactsToCSV(contacts []models.Contact) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func ParseLeadsCSV(reader io.Reader) ([]models.Lead, []RowError, error) {
+func ParseLeadsCSV(reader io.Reader) ([]models.Lead, []int, []RowError, error) {
 	headers, rows, err := readCSV(reader)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	headerIndex := indexHeaders(headers)
 	if _, ok := headerIndex["Name"]; !ok {
-		return nil, nil, fmt.Errorf("CSV is missing required header: Name")
+		return nil, nil, nil, fmt.Errorf("CSV is missing required header: Name")
 	}
 
 	validStatuses := map[string]models.LeadStatus{
@@ -358,8 +557,9 @@ func ParseLeadsCSV(reader io.Reader) ([]models.Lead, []RowError, error) {
 	}
 
 	var (
-		leads     []models.Lead
-		rowErrors []RowError
+		leads      []models.Lead
+		rowErrors  []RowError
+		rowNumbers []int
 	)
 
 	for rowIndex, row := range rows {
@@ -403,9 +603,10 @@ func ParseLeadsCSV(reader io.Reader) ([]models.Lead, []RowError, error) {
 		}
 
 		leads = append(leads, lead)
+		rowNumbers = append(rowNumbers, currentRow)
 	}
 
-	return leads, rowErrors, nil
+	return leads, rowNumbers, rowErrors, nil
 }
 
 func LeadsToCSV(leads []models.Lead) ([]byte, error) {
@@ -442,9 +643,1017 @@ func LeadsToCSV(leads []models.Lead) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+func ParseActivitiesCSV(reader io.Reader) ([]models.Activity, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"ActivityType", "Subject", "ActivityTime"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		activities []models.Activity
+		rowErrors  []RowError
+		rowNumbers []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		var accountID *uint
+		if value := valueFor(row, headerIndex, "AccountID"); value != "" {
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "AccountID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			accountID = parsed
+		}
+
+		var leadID *uint
+		if value := valueFor(row, headerIndex, "LeadID"); value != "" {
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "LeadID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			leadID = parsed
+		}
+
+		if accountID == nil && leadID == nil {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "AccountID", Message: "either AccountID or LeadID is required"})
+			continue
+		}
+
+		var contactID *uint
+		if value := valueFor(row, headerIndex, "ContactID"); value != "" {
+			if accountID == nil {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "ContactID", Message: "ContactID can only be set when AccountID is provided"})
+				continue
+			}
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "ContactID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			contactID = parsed
+		}
+
+		var employeeID *uint
+		if value := valueFor(row, headerIndex, "EmployeeID"); value != "" {
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "EmployeeID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			employeeID = parsed
+		}
+
+		var opportunityID *uint
+		if value := valueFor(row, headerIndex, "OpportunityID"); value != "" {
+			if accountID == nil {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "OpportunityID", Message: "OpportunityID can only be set when AccountID is provided"})
+				continue
+			}
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "OpportunityID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			opportunityID = parsed
+		}
+
+		activityType := valueFor(row, headerIndex, "ActivityType")
+		if activityType == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "ActivityType", Message: "is required"})
+			continue
+		}
+
+		subject := valueFor(row, headerIndex, "Subject")
+		if subject == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Subject", Message: "is required"})
+			continue
+		}
+
+		activityTime, timeErr := parseRequiredTime(valueFor(row, headerIndex, "ActivityTime"), "ActivityTime")
+		if timeErr != nil {
+			timeErr.Row = currentRow
+			rowErrors = append(rowErrors, *timeErr)
+			continue
+		}
+
+		activity := models.Activity{
+			AccountID:     accountID,
+			LeadID:        leadID,
+			ContactID:     contactID,
+			EmployeeID:    employeeID,
+			OpportunityID: opportunityID,
+			ActivityType:  activityType,
+			Subject:       subject,
+			Outcome:       valueFor(row, headerIndex, "Outcome"),
+			Notes:         valueFor(row, headerIndex, "Notes"),
+			ActivityTime:  activityTime,
+		}
+
+		activities = append(activities, activity)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return activities, rowNumbers, rowErrors, nil
+}
+
+func ActivitiesToCSV(activities []models.Activity) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(activityHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, activity := range activities {
+		record := []string{
+			uintPointerToString(activity.AccountID),
+			uintPointerToString(activity.LeadID),
+			uintPointerToString(activity.ContactID),
+			uintPointerToString(activity.EmployeeID),
+			uintPointerToString(activity.OpportunityID),
+			activity.ActivityType,
+			activity.Subject,
+			activity.Outcome,
+			activity.Notes,
+			activity.ActivityTime.UTC().Format(time.RFC3339),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseIssuesCSV(reader io.Reader) ([]models.Issue, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"AccountID", "Title"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		issues     []models.Issue
+		rowErrors  []RowError
+		rowNumbers []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		accountIDValue := valueFor(row, headerIndex, "AccountID")
+		accountID, parseErr := parseRequiredUint(accountIDValue, "AccountID")
+		if parseErr != nil {
+			parseErr.Row = currentRow
+			rowErrors = append(rowErrors, *parseErr)
+			continue
+		}
+
+		var contactID *uint
+		if value := valueFor(row, headerIndex, "ContactID"); value != "" {
+			parsed, err := parseOptionalUint(value)
+			if err != nil {
+				err.Row = currentRow
+				err.Field = "ContactID"
+				rowErrors = append(rowErrors, *err)
+				continue
+			}
+			contactID = parsed
+		}
+
+		title := valueFor(row, headerIndex, "Title")
+		if title == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Title", Message: "is required"})
+			continue
+		}
+
+		status := models.IssueStatusNew
+		if value := valueFor(row, headerIndex, "Status"); value != "" {
+			if parsed, ok := issueStatusByName[strings.ToLower(value)]; ok {
+				status = parsed
+			} else {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Status", Message: "must be one of New, InProgress, Pending, Resolved, Closed"})
+				continue
+			}
+		}
+
+		priority := models.IssuePriorityMedium
+		if value := valueFor(row, headerIndex, "Priority"); value != "" {
+			if parsed, ok := issuePriorityByName[strings.ToLower(value)]; ok {
+				priority = parsed
+			} else {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Priority", Message: "must be one of Low, Medium, High, Critical"})
+				continue
+			}
+		}
+
+		var employeeID *uint
+		if value := valueFor(row, headerIndex, "EmployeeID"); value != "" {
+			parsed, err := parseOptionalUint(value)
+			if err != nil {
+				err.Row = currentRow
+				err.Field = "EmployeeID"
+				rowErrors = append(rowErrors, *err)
+				continue
+			}
+			employeeID = parsed
+		}
+
+		dueDate, dueErr := parseOptionalTime(valueFor(row, headerIndex, "DueDate"), "DueDate")
+		if dueErr != nil {
+			dueErr.Row = currentRow
+			rowErrors = append(rowErrors, *dueErr)
+			continue
+		}
+
+		resolvedAt, resolvedErr := parseOptionalTime(valueFor(row, headerIndex, "ResolvedAt"), "ResolvedAt")
+		if resolvedErr != nil {
+			resolvedErr.Row = currentRow
+			rowErrors = append(rowErrors, *resolvedErr)
+			continue
+		}
+
+		issue := models.Issue{
+			AccountID:   accountID,
+			ContactID:   contactID,
+			Title:       title,
+			Description: valueFor(row, headerIndex, "Description"),
+			Status:      status,
+			Priority:    priority,
+			AssignedTo:  valueFor(row, headerIndex, "AssignedTo"),
+			Resolution:  valueFor(row, headerIndex, "Resolution"),
+			EmployeeID:  employeeID,
+			DueDate:     dueDate,
+			ResolvedAt:  resolvedAt,
+		}
+
+		issues = append(issues, issue)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return issues, rowNumbers, rowErrors, nil
+}
+
+func IssuesToCSV(issues []models.Issue) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(issueHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, issue := range issues {
+		record := []string{
+			strconv.FormatUint(uint64(issue.AccountID), 10),
+			uintPointerToString(issue.ContactID),
+			issue.Title,
+			issue.Description,
+			issue.Status.String(),
+			issue.Priority.String(),
+			issue.AssignedTo,
+			issue.Resolution,
+			uintPointerToString(issue.EmployeeID),
+			timePointerToString(issue.DueDate),
+			timePointerToString(issue.ResolvedAt),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseTasksCSV(reader io.Reader) ([]models.Task, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"Title", "Owner", "DueDate"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		tasks      []models.Task
+		rowErrors  []RowError
+		rowNumbers []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		var accountID *uint
+		if value := valueFor(row, headerIndex, "AccountID"); value != "" {
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "AccountID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			accountID = parsed
+		}
+
+		var leadID *uint
+		if value := valueFor(row, headerIndex, "LeadID"); value != "" {
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "LeadID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			leadID = parsed
+		}
+
+		if accountID == nil && leadID == nil {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "AccountID", Message: "either AccountID or LeadID is required"})
+			continue
+		}
+
+		var contactID *uint
+		if value := valueFor(row, headerIndex, "ContactID"); value != "" {
+			if accountID == nil {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "ContactID", Message: "ContactID can only be set when AccountID is provided"})
+				continue
+			}
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "ContactID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			contactID = parsed
+		}
+
+		var employeeID *uint
+		if value := valueFor(row, headerIndex, "EmployeeID"); value != "" {
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "EmployeeID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			employeeID = parsed
+		}
+
+		var opportunityID *uint
+		if value := valueFor(row, headerIndex, "OpportunityID"); value != "" {
+			if accountID == nil {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "OpportunityID", Message: "OpportunityID can only be set when AccountID is provided"})
+				continue
+			}
+			parsed, parseErr := parseOptionalUint(value)
+			if parseErr != nil {
+				parseErr.Row = currentRow
+				parseErr.Field = "OpportunityID"
+				rowErrors = append(rowErrors, *parseErr)
+				continue
+			}
+			opportunityID = parsed
+		}
+
+		title := valueFor(row, headerIndex, "Title")
+		if title == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Title", Message: "is required"})
+			continue
+		}
+
+		owner := valueFor(row, headerIndex, "Owner")
+		if owner == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Owner", Message: "is required"})
+			continue
+		}
+
+		status := models.TaskStatusNotStarted
+		if value := valueFor(row, headerIndex, "Status"); value != "" {
+			if parsed, ok := taskStatusByName[strings.ToLower(value)]; ok {
+				status = parsed
+			} else {
+				rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Status", Message: "must be one of NotStarted, InProgress, Completed, Deferred, Cancelled"})
+				continue
+			}
+		}
+
+		dueDate, dueErr := parseRequiredTime(valueFor(row, headerIndex, "DueDate"), "DueDate")
+		if dueErr != nil {
+			dueErr.Row = currentRow
+			rowErrors = append(rowErrors, *dueErr)
+			continue
+		}
+
+		completedAt, completedErr := parseOptionalTime(valueFor(row, headerIndex, "CompletedAt"), "CompletedAt")
+		if completedErr != nil {
+			completedErr.Row = currentRow
+			rowErrors = append(rowErrors, *completedErr)
+			continue
+		}
+
+		task := models.Task{
+			AccountID:     accountID,
+			LeadID:        leadID,
+			ContactID:     contactID,
+			EmployeeID:    employeeID,
+			OpportunityID: opportunityID,
+			Title:         title,
+			Description:   valueFor(row, headerIndex, "Description"),
+			Owner:         owner,
+			Status:        status,
+			DueDate:       dueDate,
+			CompletedAt:   completedAt,
+		}
+
+		tasks = append(tasks, task)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return tasks, rowNumbers, rowErrors, nil
+}
+
+func TasksToCSV(tasks []models.Task) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(taskHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, task := range tasks {
+		record := []string{
+			uintPointerToString(task.AccountID),
+			uintPointerToString(task.LeadID),
+			uintPointerToString(task.ContactID),
+			uintPointerToString(task.EmployeeID),
+			uintPointerToString(task.OpportunityID),
+			task.Title,
+			task.Description,
+			task.Owner,
+			task.Status.String(),
+			task.DueDate.UTC().Format(time.RFC3339),
+			timePointerToString(task.CompletedAt),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseOpportunitiesCSV(reader io.Reader) ([]models.Opportunity, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"AccountID", "Name", "Amount", "Probability", "Stage"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		opportunities []models.Opportunity
+		rowErrors     []RowError
+		rowNumbers    []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		accountIDValue := valueFor(row, headerIndex, "AccountID")
+		accountID, parseErr := parseRequiredUint(accountIDValue, "AccountID")
+		if parseErr != nil {
+			parseErr.Row = currentRow
+			rowErrors = append(rowErrors, *parseErr)
+			continue
+		}
+
+		var contactID *uint
+		if value := valueFor(row, headerIndex, "ContactID"); value != "" {
+			parsed, err := parseOptionalUint(value)
+			if err != nil {
+				err.Row = currentRow
+				err.Field = "ContactID"
+				rowErrors = append(rowErrors, *err)
+				continue
+			}
+			contactID = parsed
+		}
+
+		var ownerEmployeeID *uint
+		if value := valueFor(row, headerIndex, "OwnerEmployeeID"); value != "" {
+			parsed, err := parseOptionalUint(value)
+			if err != nil {
+				err.Row = currentRow
+				err.Field = "OwnerEmployeeID"
+				rowErrors = append(rowErrors, *err)
+				continue
+			}
+			ownerEmployeeID = parsed
+		}
+
+		name := valueFor(row, headerIndex, "Name")
+		if name == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Name", Message: "is required"})
+			continue
+		}
+
+		amount, amountErr := parseRequiredFloat(valueFor(row, headerIndex, "Amount"), "Amount")
+		if amountErr != nil {
+			amountErr.Row = currentRow
+			rowErrors = append(rowErrors, *amountErr)
+			continue
+		}
+
+		probability, probErr := parseRequiredInt(valueFor(row, headerIndex, "Probability"), "Probability")
+		if probErr != nil {
+			probErr.Row = currentRow
+			rowErrors = append(rowErrors, *probErr)
+			continue
+		}
+		if probability < 0 || probability > 100 {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Probability", Message: "must be between 0 and 100"})
+			continue
+		}
+
+		stageValue := valueFor(row, headerIndex, "Stage")
+		stage, ok := opportunityStageByName[strings.ToLower(stageValue)]
+		if !ok {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Stage", Message: "must be a valid opportunity stage"})
+			continue
+		}
+
+		expectedCloseDate, expectedErr := parseOptionalTime(valueFor(row, headerIndex, "ExpectedCloseDate"), "ExpectedCloseDate")
+		if expectedErr != nil {
+			expectedErr.Row = currentRow
+			rowErrors = append(rowErrors, *expectedErr)
+			continue
+		}
+
+		closedAt, closedAtErr := parseOptionalTime(valueFor(row, headerIndex, "ClosedAt"), "ClosedAt")
+		if closedAtErr != nil {
+			closedAtErr.Row = currentRow
+			rowErrors = append(rowErrors, *closedAtErr)
+			continue
+		}
+
+		var closedByEmployeeID *uint
+		if value := valueFor(row, headerIndex, "ClosedByEmployeeID"); value != "" {
+			parsed, err := parseOptionalUint(value)
+			if err != nil {
+				err.Row = currentRow
+				err.Field = "ClosedByEmployeeID"
+				rowErrors = append(rowErrors, *err)
+				continue
+			}
+			closedByEmployeeID = parsed
+		}
+
+		opportunity := models.Opportunity{
+			AccountID:          accountID,
+			ContactID:          contactID,
+			OwnerEmployeeID:    ownerEmployeeID,
+			Name:               name,
+			Amount:             amount,
+			Probability:        probability,
+			ExpectedCloseDate:  expectedCloseDate,
+			Stage:              stage,
+			Description:        valueFor(row, headerIndex, "Description"),
+			ClosedAt:           closedAt,
+			CloseReason:        valueFor(row, headerIndex, "CloseReason"),
+			ClosedByEmployeeID: closedByEmployeeID,
+		}
+
+		opportunities = append(opportunities, opportunity)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return opportunities, rowNumbers, rowErrors, nil
+}
+
+func OpportunitiesToCSV(opportunities []models.Opportunity) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(opportunityHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, opportunity := range opportunities {
+		record := []string{
+			strconv.FormatUint(uint64(opportunity.AccountID), 10),
+			uintPointerToString(opportunity.ContactID),
+			uintPointerToString(opportunity.OwnerEmployeeID),
+			opportunity.Name,
+			formatFloat(opportunity.Amount),
+			strconv.Itoa(opportunity.Probability),
+			timePointerToString(opportunity.ExpectedCloseDate),
+			opportunity.Stage.String(),
+			opportunity.Description,
+			timePointerToString(opportunity.ClosedAt),
+			opportunity.CloseReason,
+			uintPointerToString(opportunity.ClosedByEmployeeID),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseOpportunityLineItemsCSV(reader io.Reader) ([]models.OpportunityLineItem, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"OpportunityID", "ProductID", "Quantity", "UnitPrice"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		items      []models.OpportunityLineItem
+		rowErrors  []RowError
+		rowNumbers []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		opportunityIDValue := valueFor(row, headerIndex, "OpportunityID")
+		opportunityID, parseErr := parseRequiredUint(opportunityIDValue, "OpportunityID")
+		if parseErr != nil {
+			parseErr.Row = currentRow
+			rowErrors = append(rowErrors, *parseErr)
+			continue
+		}
+
+		productIDValue := valueFor(row, headerIndex, "ProductID")
+		productID, parseErr := parseRequiredUint(productIDValue, "ProductID")
+		if parseErr != nil {
+			parseErr.Row = currentRow
+			rowErrors = append(rowErrors, *parseErr)
+			continue
+		}
+
+		quantity, quantityErr := parseRequiredInt(valueFor(row, headerIndex, "Quantity"), "Quantity")
+		if quantityErr != nil {
+			quantityErr.Row = currentRow
+			rowErrors = append(rowErrors, *quantityErr)
+			continue
+		}
+		if quantity <= 0 {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Quantity", Message: "must be greater than zero"})
+			continue
+		}
+
+		unitPrice, priceErr := parseRequiredFloat(valueFor(row, headerIndex, "UnitPrice"), "UnitPrice")
+		if priceErr != nil {
+			priceErr.Row = currentRow
+			rowErrors = append(rowErrors, *priceErr)
+			continue
+		}
+
+		discountAmount, discountAmountErr := parseOptionalFloat(valueFor(row, headerIndex, "DiscountAmount"), "DiscountAmount")
+		if discountAmountErr != nil {
+			discountAmountErr.Row = currentRow
+			rowErrors = append(rowErrors, *discountAmountErr)
+			continue
+		}
+
+		discountPercent, discountPercentErr := parseOptionalFloat(valueFor(row, headerIndex, "DiscountPercent"), "DiscountPercent")
+		if discountPercentErr != nil {
+			discountPercentErr.Row = currentRow
+			rowErrors = append(rowErrors, *discountPercentErr)
+			continue
+		}
+
+		item := models.OpportunityLineItem{
+			OpportunityID:   opportunityID,
+			ProductID:       productID,
+			Quantity:        quantity,
+			UnitPrice:       unitPrice,
+			DiscountAmount:  discountAmount,
+			DiscountPercent: discountPercent,
+		}
+
+		items = append(items, item)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return items, rowNumbers, rowErrors, nil
+}
+
+func OpportunityLineItemsToCSV(items []models.OpportunityLineItem) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(opportunityLineItemHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, item := range items {
+		record := []string{
+			strconv.FormatUint(uint64(item.OpportunityID), 10),
+			strconv.FormatUint(uint64(item.ProductID), 10),
+			strconv.Itoa(item.Quantity),
+			formatFloat(item.UnitPrice),
+			formatFloat(item.DiscountAmount),
+			formatFloat(item.DiscountPercent),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseEmployeesCSV(reader io.Reader) ([]models.Employee, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	requiredHeaders := []string{"FirstName", "LastName"}
+	for _, header := range requiredHeaders {
+		if _, ok := headerIndex[header]; !ok {
+			return nil, nil, nil, fmt.Errorf("CSV is missing required header: %s", header)
+		}
+	}
+
+	var (
+		employees  []models.Employee
+		rowErrors  []RowError
+		rowNumbers []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		firstName := valueFor(row, headerIndex, "FirstName")
+		if firstName == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "FirstName", Message: "is required"})
+			continue
+		}
+
+		lastName := valueFor(row, headerIndex, "LastName")
+		if lastName == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "LastName", Message: "is required"})
+			continue
+		}
+
+		hireDate, hireDateErr := parseOptionalTime(valueFor(row, headerIndex, "HireDate"), "HireDate")
+		if hireDateErr != nil {
+			hireDateErr.Row = currentRow
+			rowErrors = append(rowErrors, *hireDateErr)
+			continue
+		}
+
+		employee := models.Employee{
+			FirstName:  firstName,
+			LastName:   lastName,
+			Email:      valueFor(row, headerIndex, "Email"),
+			Phone:      valueFor(row, headerIndex, "Phone"),
+			Department: valueFor(row, headerIndex, "Department"),
+			Position:   valueFor(row, headerIndex, "Position"),
+			HireDate:   hireDate,
+			Notes:      valueFor(row, headerIndex, "Notes"),
+		}
+
+		employees = append(employees, employee)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return employees, rowNumbers, rowErrors, nil
+}
+
+func EmployeesToCSV(employees []models.Employee) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(employeeHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, employee := range employees {
+		record := []string{
+			employee.FirstName,
+			employee.LastName,
+			employee.Email,
+			employee.Phone,
+			employee.Department,
+			employee.Position,
+			timePointerToString(employee.HireDate),
+			employee.Notes,
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func ParseProductsCSV(reader io.Reader) ([]models.Product, []int, []RowError, error) {
+	headers, rows, err := readCSV(reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	headerIndex := indexHeaders(headers)
+	if _, ok := headerIndex["Name"]; !ok {
+		return nil, nil, nil, fmt.Errorf("CSV is missing required header: Name")
+	}
+
+	var (
+		products   []models.Product
+		rowErrors  []RowError
+		rowNumbers []int
+	)
+
+	for rowIndex, row := range rows {
+		currentRow := rowIndex + 2
+
+		name := valueFor(row, headerIndex, "Name")
+		if name == "" {
+			rowErrors = append(rowErrors, RowError{Row: currentRow, Field: "Name", Message: "is required"})
+			continue
+		}
+
+		price, priceErr := parseOptionalFloat(valueFor(row, headerIndex, "Price"), "Price")
+		if priceErr != nil {
+			priceErr.Row = currentRow
+			rowErrors = append(rowErrors, *priceErr)
+			continue
+		}
+
+		cost, costErr := parseOptionalFloat(valueFor(row, headerIndex, "Cost"), "Cost")
+		if costErr != nil {
+			costErr.Row = currentRow
+			rowErrors = append(rowErrors, *costErr)
+			continue
+		}
+
+		stock, stockErr := parseOptionalInt(valueFor(row, headerIndex, "Stock"), "Stock")
+		if stockErr != nil {
+			stockErr.Row = currentRow
+			rowErrors = append(rowErrors, *stockErr)
+			continue
+		}
+
+		isActive := true
+		if value := valueFor(row, headerIndex, "IsActive"); value != "" {
+			parsed, boolErr := parseOptionalBool(value, "IsActive")
+			if boolErr != nil {
+				boolErr.Row = currentRow
+				rowErrors = append(rowErrors, *boolErr)
+				continue
+			}
+			if parsed != nil {
+				isActive = *parsed
+			}
+		}
+
+		product := models.Product{
+			Name:        name,
+			SKU:         valueFor(row, headerIndex, "SKU"),
+			Category:    valueFor(row, headerIndex, "Category"),
+			Description: valueFor(row, headerIndex, "Description"),
+			Price:       price,
+			Cost:        cost,
+			Stock:       stock,
+			IsActive:    isActive,
+		}
+
+		products = append(products, product)
+		rowNumbers = append(rowNumbers, currentRow)
+	}
+
+	return products, rowNumbers, rowErrors, nil
+}
+
+func ProductsToCSV(products []models.Product) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+
+	if err := writer.Write(productHeaders); err != nil {
+		return nil, err
+	}
+
+	for _, product := range products {
+		record := []string{
+			product.Name,
+			product.SKU,
+			product.Category,
+			product.Description,
+			formatFloat(product.Price),
+			formatFloat(product.Cost),
+			strconv.Itoa(product.Stock),
+			strconv.FormatBool(product.IsActive),
+		}
+		if err := writer.Write(record); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
 func uintPointerToString(value *uint) string {
 	if value == nil {
 		return ""
 	}
 	return strconv.FormatUint(uint64(*value), 10)
+}
+
+func timePointerToString(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func formatFloat(value float64) string {
+	return strconv.FormatFloat(value, 'f', 2, 64)
 }

--- a/backend/models/task.go
+++ b/backend/models/task.go
@@ -19,6 +19,24 @@ const (
 	TaskStatusCancelled  TaskStatus = 5
 )
 
+// String returns the string representation of TaskStatus
+func (s TaskStatus) String() string {
+	switch s {
+	case TaskStatusNotStarted:
+		return "NotStarted"
+	case TaskStatusInProgress:
+		return "InProgress"
+	case TaskStatusCompleted:
+		return "Completed"
+	case TaskStatusDeferred:
+		return "Deferred"
+	case TaskStatusCancelled:
+		return "Cancelled"
+	default:
+		return "Unknown"
+	}
+}
+
 // Task represents a follow-up item associated with an account
 // Tasks capture accountability with an owner, status and due date.
 type Task struct {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,6 +44,7 @@ All pages support CRUD operations and are fully integrated with the OData v4 bac
 - **Accounts**: List, view, create, and edit accounts
 - **Contacts**: Manage contacts associated with accounts
 - **Issues**: Track and manage support tickets
+- **Data Cockpit**: Catalog of CSV import/export actions for every entity
 
 ## Development
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,49 +1,49 @@
-import { useEffect } from 'react'
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
-import { ThemeProvider } from './contexts/ThemeContext'
-import { AuthProvider } from './contexts/AuthContext'
-import ProtectedRoute from './components/ProtectedRoute'
-import Layout from './components/Layout'
-import Login from './pages/Login'
-import Dashboard from './pages/Dashboard'
-import AccountsList from './pages/Accounts/AccountsList'
-import AccountDetail from './pages/Accounts/AccountDetail'
-import AccountForm from './pages/Accounts/AccountForm'
-import LeadsList from './pages/Leads/LeadsList'
-import LeadDetail from './pages/Leads/LeadDetail'
-import LeadForm from './pages/Leads/LeadForm'
-import ContactsList from './pages/Contacts/ContactsList'
-import ContactDetail from './pages/Contacts/ContactDetail'
-import ContactForm from './pages/Contacts/ContactForm'
-import ActivitiesList from './pages/Activities/ActivitiesList'
-import ActivityDetail from './pages/Activities/ActivityDetail'
-import ActivityForm from './pages/Activities/ActivityForm'
-import IssuesList from './pages/Issues/IssuesList'
-import IssueDetail from './pages/Issues/IssueDetail'
-import IssueForm from './pages/Issues/IssueForm'
-import TasksList from './pages/Tasks/TasksList'
-import TaskDetail from './pages/Tasks/TaskDetail'
-import TaskForm from './pages/Tasks/TaskForm'
-import OpportunitiesList from './pages/Opportunities/OpportunitiesList'
-import OpportunitiesBoard from './pages/Opportunities/OpportunitiesBoard'
-import OpportunityDetail from './pages/Opportunities/OpportunityDetail'
-import OpportunityForm from './pages/Opportunities/OpportunityForm'
-import EmployeesList from './pages/Employees/EmployeesList'
-import EmployeeDetail from './pages/Employees/EmployeeDetail'
-import EmployeeForm from './pages/Employees/EmployeeForm'
-import ProductsList from './pages/Products/ProductsList'
-import ProductDetail from './pages/Products/ProductDetail'
-import ProductForm from './pages/Products/ProductForm'
-import WorkflowSettingsPage from './pages/Settings/Workflows'
-import UserPreferences from './pages/Settings/UserPreferences'
-import MigrationCockpit from './pages/Migration/MigrationCockpit'
-import { fetchEnums } from './lib/enums'
+import { useEffect } from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "./contexts/ThemeContext";
+import { AuthProvider } from "./contexts/AuthContext";
+import ProtectedRoute from "./components/ProtectedRoute";
+import Layout from "./components/Layout";
+import Login from "./pages/Login";
+import Dashboard from "./pages/Dashboard";
+import AccountsList from "./pages/Accounts/AccountsList";
+import AccountDetail from "./pages/Accounts/AccountDetail";
+import AccountForm from "./pages/Accounts/AccountForm";
+import LeadsList from "./pages/Leads/LeadsList";
+import LeadDetail from "./pages/Leads/LeadDetail";
+import LeadForm from "./pages/Leads/LeadForm";
+import ContactsList from "./pages/Contacts/ContactsList";
+import ContactDetail from "./pages/Contacts/ContactDetail";
+import ContactForm from "./pages/Contacts/ContactForm";
+import ActivitiesList from "./pages/Activities/ActivitiesList";
+import ActivityDetail from "./pages/Activities/ActivityDetail";
+import ActivityForm from "./pages/Activities/ActivityForm";
+import IssuesList from "./pages/Issues/IssuesList";
+import IssueDetail from "./pages/Issues/IssueDetail";
+import IssueForm from "./pages/Issues/IssueForm";
+import TasksList from "./pages/Tasks/TasksList";
+import TaskDetail from "./pages/Tasks/TaskDetail";
+import TaskForm from "./pages/Tasks/TaskForm";
+import OpportunitiesList from "./pages/Opportunities/OpportunitiesList";
+import OpportunitiesBoard from "./pages/Opportunities/OpportunitiesBoard";
+import OpportunityDetail from "./pages/Opportunities/OpportunityDetail";
+import OpportunityForm from "./pages/Opportunities/OpportunityForm";
+import EmployeesList from "./pages/Employees/EmployeesList";
+import EmployeeDetail from "./pages/Employees/EmployeeDetail";
+import EmployeeForm from "./pages/Employees/EmployeeForm";
+import ProductsList from "./pages/Products/ProductsList";
+import ProductDetail from "./pages/Products/ProductDetail";
+import ProductForm from "./pages/Products/ProductForm";
+import WorkflowSettingsPage from "./pages/Settings/Workflows";
+import UserPreferences from "./pages/Settings/UserPreferences";
+import DataCockpit from "./pages/Settings/DataCockpit";
+import { fetchEnums } from "./lib/enums";
 
 function App() {
   // Fetch enum definitions from backend on app initialization
   useEffect(() => {
-    fetchEnums()
-  }, [])
+    fetchEnums();
+  }, []);
   return (
     <ThemeProvider>
       <AuthProvider>
@@ -51,13 +51,17 @@ function App() {
           <Routes>
             {/* Public route */}
             <Route path="/login" element={<Login />} />
-            
-            {/* Protected routes */}
-            <Route path="/" element={<ProtectedRoute><Layout /></ProtectedRoute>}>
-              <Route index element={<Dashboard />} />
 
-              {/* Migration routes */}
-              <Route path="migration" element={<MigrationCockpit />} />
+            {/* Protected routes */}
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <Layout />
+                </ProtectedRoute>
+              }
+            >
+              <Route index element={<Dashboard />} />
 
               {/* Accounts routes */}
               <Route path="accounts" element={<AccountsList />} />
@@ -97,10 +101,16 @@ function App() {
 
               {/* Opportunities routes */}
               <Route path="opportunities" element={<OpportunitiesList />} />
-              <Route path="opportunities/board" element={<OpportunitiesBoard />} />
+              <Route
+                path="opportunities/board"
+                element={<OpportunitiesBoard />}
+              />
               <Route path="opportunities/new" element={<OpportunityForm />} />
               <Route path="opportunities/:id" element={<OpportunityDetail />} />
-              <Route path="opportunities/:id/edit" element={<OpportunityForm />} />
+              <Route
+                path="opportunities/:id/edit"
+                element={<OpportunityForm />}
+              />
 
               {/* Employees routes */}
               <Route path="employees" element={<EmployeesList />} />
@@ -115,14 +125,21 @@ function App() {
               <Route path="products/:id/edit" element={<ProductForm />} />
 
               {/* Settings routes */}
-              <Route path="settings/workflows" element={<WorkflowSettingsPage />} />
-              <Route path="settings/preferences" element={<UserPreferences />} />
+              <Route
+                path="settings/workflows"
+                element={<WorkflowSettingsPage />}
+              />
+              <Route
+                path="settings/preferences"
+                element={<UserPreferences />}
+              />
+              <Route path="settings/data" element={<DataCockpit />} />
             </Route>
           </Routes>
         </Router>
       </AuthProvider>
     </ThemeProvider>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,168 +1,190 @@
-import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom'
-import { useEffect, useRef, useState } from 'react'
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { useAuth } from '../hooks/useAuth'
-import { Input } from './ui'
-import { useGlobalSearch } from '../hooks/useGlobalSearch'
-import { GlobalSearchResults } from './GlobalSearchResults'
-import type { GlobalSearchResult } from './searchTypes'
+import { Outlet, Link, useLocation, useNavigate } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useAuth } from "../hooks/useAuth";
+import { Input } from "./ui";
+import { useGlobalSearch } from "../hooks/useGlobalSearch";
+import { GlobalSearchResults } from "./GlobalSearchResults";
+import type { GlobalSearchResult } from "./searchTypes";
 
 export default function Layout() {
-  const location = useLocation()
-  const navigate = useNavigate()
-  const { user, logout } = useAuth()
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [debouncedSearch, setDebouncedSearch] = useState('')
-  const [isSearchActive, setIsSearchActive] = useState(false)
-  const searchContainerRef = useRef<HTMLDivElement>(null)
-  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false)
-  const profileMenuRef = useRef<HTMLDivElement>(null)
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [isSearchActive, setIsSearchActive] = useState(false);
+  const searchContainerRef = useRef<HTMLDivElement>(null);
+  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+  const profileMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
-      setDebouncedSearch(searchTerm)
-    }, 250)
+      setDebouncedSearch(searchTerm);
+    }, 250);
 
-    return () => window.clearTimeout(timeout)
-  }, [searchTerm])
+    return () => window.clearTimeout(timeout);
+  }, [searchTerm]);
 
   useEffect(() => {
     if (!isSearchActive) {
-      return
+      return;
     }
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (searchContainerRef.current && !searchContainerRef.current.contains(event.target as Node)) {
-        setIsSearchActive(false)
+      if (
+        searchContainerRef.current &&
+        !searchContainerRef.current.contains(event.target as Node)
+      ) {
+        setIsSearchActive(false);
       }
-    }
+    };
 
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [isSearchActive])
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isSearchActive]);
 
-  const {
-    data: globalSearchResults = [],
-    isLoading: isGlobalSearchLoading,
-  } = useGlobalSearch(debouncedSearch, 5)
+  const { data: globalSearchResults = [], isLoading: isGlobalSearchLoading } =
+    useGlobalSearch(debouncedSearch, 5);
 
   const handleSearchSelect = (result: GlobalSearchResult) => {
-    setSearchTerm('')
-    setDebouncedSearch('')
-    setIsSearchActive(false)
-    navigate(result.path)
-  }
+    setSearchTerm("");
+    setDebouncedSearch("");
+    setIsSearchActive(false);
+    navigate(result.path);
+  };
 
   const handleSearchKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter' && globalSearchResults.length > 0) {
-      event.preventDefault()
-      handleSearchSelect(globalSearchResults[0])
+    if (event.key === "Enter" && globalSearchResults.length > 0) {
+      event.preventDefault();
+      handleSearchSelect(globalSearchResults[0]);
     }
 
-    if (event.key === 'Escape') {
-      setIsSearchActive(false)
+    if (event.key === "Escape") {
+      setIsSearchActive(false);
     }
-  }
+  };
 
-  const shouldShowSearchResults = isSearchActive && debouncedSearch.trim().length > 0
+  const shouldShowSearchResults =
+    isSearchActive && debouncedSearch.trim().length > 0;
 
-  const userInitials = [user?.firstName?.[0], user?.lastName?.[0]]
-    .filter(Boolean)
-    .join('')
-    .toUpperCase() || user?.email?.[0]?.toUpperCase() || '?'
+  const userInitials =
+    [user?.firstName?.[0], user?.lastName?.[0]]
+      .filter(Boolean)
+      .join("")
+      .toUpperCase() ||
+    user?.email?.[0]?.toUpperCase() ||
+    "?";
 
-  const profileAriaLabel = user?.firstName || user?.lastName
-    ? `Open profile menu for ${[user?.firstName, user?.lastName].filter(Boolean).join(' ')}`
-    : 'Open profile menu'
+  const profileAriaLabel =
+    user?.firstName || user?.lastName
+      ? `Open profile menu for ${[user?.firstName, user?.lastName].filter(Boolean).join(" ")}`
+      : "Open profile menu";
 
   type NavigationItem = {
-    name: string
-    href: string
-    exact?: boolean
-    excludePrefixes?: string[]
-  }
+    name: string;
+    href: string;
+    exact?: boolean;
+    excludePrefixes?: string[];
+  };
 
   const navigation: NavigationItem[] = [
-    { name: 'Accounts', href: '/accounts' },
-    { name: 'Leads', href: '/leads' },
-    { name: 'Contacts', href: '/contacts' },
-    { name: 'Activities', href: '/activities' },
-    { name: 'Issues', href: '/issues' },
-    { name: 'Tasks', href: '/tasks' },
-    { name: 'Opportunities', href: '/opportunities', excludePrefixes: ['/opportunities/board'] },
-    { name: 'Pipeline Board', href: '/opportunities/board', exact: true },
-    { name: 'Employees', href: '/employees' },
-    { name: 'Products', href: '/products' },
-    { name: 'Migration Cockpit', href: '/migration', exact: true },
-    { name: 'Workflows', href: '/settings/workflows' },
-  ]
+    { name: "Accounts", href: "/accounts" },
+    { name: "Leads", href: "/leads" },
+    { name: "Contacts", href: "/contacts" },
+    { name: "Activities", href: "/activities" },
+    { name: "Issues", href: "/issues" },
+    { name: "Tasks", href: "/tasks" },
+    {
+      name: "Opportunities",
+      href: "/opportunities",
+      excludePrefixes: ["/opportunities/board"],
+    },
+    { name: "Pipeline Board", href: "/opportunities/board", exact: true },
+    { name: "Employees", href: "/employees" },
+    { name: "Products", href: "/products" },
+    { name: "Data Cockpit", href: "/settings/data" },
+    { name: "Workflows", href: "/settings/workflows" },
+  ];
 
-  const isActive = (path: string, options?: { exact?: boolean; excludePrefixes?: string[] }) => {
+  const isActive = (
+    path: string,
+    options?: { exact?: boolean; excludePrefixes?: string[] },
+  ) => {
     if (options?.exact) {
-      return location.pathname === path
+      return location.pathname === path;
     }
 
-    if (options?.excludePrefixes?.some((prefix) => location.pathname.startsWith(prefix))) {
-      return false
+    if (
+      options?.excludePrefixes?.some((prefix) =>
+        location.pathname.startsWith(prefix),
+      )
+    ) {
+      return false;
     }
 
-    return location.pathname === path || location.pathname.startsWith(`${path}/`)
-  }
+    return (
+      location.pathname === path || location.pathname.startsWith(`${path}/`)
+    );
+  };
 
   const toggleMobileMenu = () => {
-    setIsMobileMenuOpen(!isMobileMenuOpen)
-  }
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
 
   const closeMobileMenu = () => {
-    setIsMobileMenuOpen(false)
-  }
+    setIsMobileMenuOpen(false);
+  };
 
   const toggleProfileMenu = () => {
-    setIsProfileMenuOpen((previous) => !previous)
-  }
+    setIsProfileMenuOpen((previous) => !previous);
+  };
 
   const handleLogout = () => {
-    setIsProfileMenuOpen(false)
-    logout()
-    navigate('/login')
-  }
+    setIsProfileMenuOpen(false);
+    logout();
+    navigate("/login");
+  };
 
   useEffect(() => {
     if (!isProfileMenuOpen) {
-      return
+      return;
     }
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (profileMenuRef.current && !profileMenuRef.current.contains(event.target as Node)) {
-        setIsProfileMenuOpen(false)
+      if (
+        profileMenuRef.current &&
+        !profileMenuRef.current.contains(event.target as Node)
+      ) {
+        setIsProfileMenuOpen(false);
       }
-    }
+    };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsProfileMenuOpen(false)
+      if (event.key === "Escape") {
+        setIsProfileMenuOpen(false);
       }
-    }
+    };
 
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [isProfileMenuOpen])
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isProfileMenuOpen]);
 
   useEffect(() => {
     if (!isProfileMenuOpen) {
-      return
+      return;
     }
 
     return () => {
-      setIsProfileMenuOpen(false)
-    }
-  }, [isProfileMenuOpen, location.pathname])
+      setIsProfileMenuOpen(false);
+    };
+  }, [isProfileMenuOpen, location.pathname]);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
@@ -179,12 +201,32 @@ export default function Layout() {
                 aria-expanded={isMobileMenuOpen}
               >
                 {isMobileMenuOpen ? (
-                  <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  <svg
+                    className="w-6 h-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 ) : (
-                  <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  <svg
+                    className="w-6 h-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 6h16M4 12h16M4 18h16"
+                    />
                   </svg>
                 )}
               </button>
@@ -243,7 +285,9 @@ export default function Layout() {
                       <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                         {user?.firstName} {user?.lastName}
                       </p>
-                      <p className="text-xs text-gray-600 dark:text-gray-400 truncate">{user?.email}</p>
+                      <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
+                        {user?.email}
+                      </p>
                     </div>
                     <div className="py-1">
                       <Link
@@ -273,18 +317,18 @@ export default function Layout() {
       {isMobileMenuOpen && (
         <>
           {/* Backdrop */}
-          <div 
+          <div
             className="fixed inset-0 bg-gray-900/50 dark:bg-gray-950/70 z-40 transition-opacity"
             onClick={closeMobileMenu}
             aria-hidden="true"
           />
-          
+
           {/* Sidebar */}
           <nav className="fixed top-0 left-0 h-full w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 z-50 shadow-xl">
             <div className="flex flex-col h-full">
               {/* Sidebar header */}
               <div className="flex items-center justify-between h-16 px-4 border-b border-gray-200 dark:border-gray-800">
-                <Link 
+                <Link
                   to="/"
                   onClick={closeMobileMenu}
                   className="text-xl font-bold text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
@@ -296,8 +340,18 @@ export default function Layout() {
                   className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
                   aria-label="Close menu"
                 >
-                  <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  <svg
+                    className="w-6 h-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 </button>
               </div>
@@ -311,9 +365,12 @@ export default function Layout() {
                       to={item.href}
                       onClick={closeMobileMenu}
                       className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                        isActive(item.href, { exact: item.exact, excludePrefixes: item.excludePrefixes })
-                          ? 'bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-200'
-                          : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+                        isActive(item.href, {
+                          exact: item.exact,
+                          excludePrefixes: item.excludePrefixes,
+                        })
+                          ? "bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-200"
+                          : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                       }`}
                     >
                       {item.name}
@@ -331,5 +388,5 @@ export default function Layout() {
         <Outlet />
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/Settings/DataCockpit.tsx
+++ b/frontend/src/pages/Settings/DataCockpit.tsx
@@ -1,0 +1,175 @@
+const BULK_ACTIONS: Array<{
+  entity: string;
+  importAction: string;
+  exportAction: string;
+}> = [
+  {
+    entity: "Accounts",
+    importAction: "ImportAccountsCSV",
+    exportAction: "ExportAccountsCSV",
+  },
+  {
+    entity: "Contacts",
+    importAction: "ImportContactsCSV",
+    exportAction: "ExportContactsCSV",
+  },
+  {
+    entity: "Leads",
+    importAction: "ImportLeadsCSV",
+    exportAction: "ExportLeadsCSV",
+  },
+  {
+    entity: "Activities",
+    importAction: "ImportActivitiesCSV",
+    exportAction: "ExportActivitiesCSV",
+  },
+  {
+    entity: "Issues",
+    importAction: "ImportIssuesCSV",
+    exportAction: "ExportIssuesCSV",
+  },
+  {
+    entity: "Tasks",
+    importAction: "ImportTasksCSV",
+    exportAction: "ExportTasksCSV",
+  },
+  {
+    entity: "Opportunities",
+    importAction: "ImportOpportunitiesCSV",
+    exportAction: "ExportOpportunitiesCSV",
+  },
+  {
+    entity: "Opportunity Line Items",
+    importAction: "ImportOpportunityLineItemsCSV",
+    exportAction: "ExportOpportunityLineItemsCSV",
+  },
+  {
+    entity: "Employees",
+    importAction: "ImportEmployeesCSV",
+    exportAction: "ExportEmployeesCSV",
+  },
+  {
+    entity: "Products",
+    importAction: "ImportProductsCSV",
+    exportAction: "ExportProductsCSV",
+  },
+];
+
+export default function DataCockpit() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          Data Cockpit
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Centralized catalog of bulk import and export actions exposed through
+          the OData service. Use these unbound actions to seed new data, migrate
+          records, or extract point-in-time snapshots.
+        </p>
+      </div>
+
+      <div className="card p-6 space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Bulk import/export actions
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Each action is invoked with a{" "}
+            <code className="font-mono bg-gray-100 dark:bg-gray-900 px-1.5 py-0.5 rounded">
+              POST
+            </code>{" "}
+            request. Import actions accept a CSV payload and return the number
+            of created records; export actions respond with a CSV attachment.
+          </p>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-900/60">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400"
+                >
+                  Entity
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400"
+                >
+                  Import Action
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400"
+                >
+                  Export Action
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-950">
+              {BULK_ACTIONS.map((action) => (
+                <tr key={action.entity}>
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {action.entity}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                    <code className="font-mono bg-gray-100 dark:bg-gray-900 px-2 py-1 rounded">
+                      POST /{action.importAction}
+                    </code>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                    <code className="font-mono bg-gray-100 dark:bg-gray-900 px-2 py-1 rounded">
+                      POST /{action.exportAction}
+                    </code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
+          <p className="font-medium text-gray-900 dark:text-gray-100">
+            Validation responses
+          </p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              Import endpoints return{" "}
+              <code className="font-mono bg-gray-100 dark:bg-gray-900 px-1 py-0.5 rounded">
+                validation_failed
+              </code>{" "}
+              errors with row-level details when dependencies (like accounts,
+              contacts, or products) are missing.
+            </li>
+            <li>
+              Export endpoints stream UTF-8 CSV files with headers that match
+              the importer requirements.
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="card p-6 space-y-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Usage tips
+        </h2>
+        <ul className="list-disc list-inside space-y-1 text-sm text-gray-600 dark:text-gray-400">
+          <li>
+            Always include a header row that matches the expected column names
+            shown above.
+          </li>
+          <li>
+            Use RFC3339 timestamps for date and time fields to avoid parsing
+            issues.
+          </li>
+          <li>
+            Ensure referenced records (accounts, leads, employees, products)
+            exist before importing related rows.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CSV parsing/export helpers for activities, issues, tasks, opportunities, line items, employees, and products
- register import/export actions with dependency validation and expose them via documentation and the new Data Cockpit page
- add TaskStatus string helper and refresh navigation to include the Data Cockpit view

## Testing
- go test ./... *(hangs in this environment; cancelled after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_6905fb924fb08328822670ced5c5c536